### PR TITLE
Add flag to set custom CA

### DIFF
--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -18,6 +18,8 @@ package common
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -134,4 +136,8 @@ func (m InformerMap) Get(apiVersion, resource string) *dynamicinformer.ResourceI
 
 func informerMapKey(apiVersion, resource string) string {
 	return fmt.Sprintf("%s.%s", resource, apiVersion)
+}
+
+type Poster interface {
+	Post(url string, contentType string, body io.Reader) (resp *http.Response, err error)
 }

--- a/controller/composite/controller.go
+++ b/controller/composite/controller.go
@@ -62,9 +62,11 @@ type parentController struct {
 
 	updateStrategy updateStrategyMap
 	childInformers common.InformerMap
+
+	poster common.Poster
 }
 
-func newParentController(resources *dynamicdiscovery.ResourceMap, dynClient *dynamicclientset.Clientset, dynInformers *dynamicinformer.SharedInformerFactory, mcClient mcclientset.Interface, revisionLister mclisters.ControllerRevisionLister, cc *v1alpha1.CompositeController) (pc *parentController, newErr error) {
+func newParentController(resources *dynamicdiscovery.ResourceMap, dynClient *dynamicclientset.Clientset, dynInformers *dynamicinformer.SharedInformerFactory, mcClient mcclientset.Interface, revisionLister mclisters.ControllerRevisionLister, cc *v1alpha1.CompositeController, poster common.Poster) (pc *parentController, newErr error) {
 	// Make a dynamic client for the parent resource.
 	parentClient, err := dynClient.Resource(cc.Spec.ParentResource.APIVersion, cc.Spec.ParentResource.Resource, "")
 	if err != nil {
@@ -115,6 +117,7 @@ func newParentController(resources *dynamicdiscovery.ResourceMap, dynClient *dyn
 		revisionLister: revisionLister,
 		updateStrategy: updateStrategy,
 		queue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CompositeController-"+cc.Name),
+		poster:         poster,
 	}
 
 	return pc, nil

--- a/controller/composite/controller_revision.go
+++ b/controller/composite/controller_revision.go
@@ -83,7 +83,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 			Parent:     parent,
 			Children:   observedChildren,
 		}
-		syncResult, err := callSyncHook(pc.cc, syncRequest)
+		syncResult, err := callSyncHook(pc.cc, pc.poster, syncRequest)
 		if err != nil {
 			return nil, nil, fmt.Errorf("sync hook failed for %v %v/%v: %v", pc.parentResource.Kind, parent.GetNamespace(), parent.GetName(), err)
 		}
@@ -153,7 +153,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 				Parent:     pr.parent,
 				Children:   observedChildren,
 			}
-			syncResult, err := callSyncHook(pc.cc, syncRequest)
+			syncResult, err := callSyncHook(pc.cc, pc.poster, syncRequest)
 			if err != nil {
 				pr.syncError = err
 				return

--- a/controller/composite/hooks.go
+++ b/controller/composite/hooks.go
@@ -38,12 +38,12 @@ type syncHookResponse struct {
 	Children []*unstructured.Unstructured `json:"children"`
 }
 
-func callSyncHook(cc *v1alpha1.CompositeController, request *syncHookRequest) (*syncHookResponse, error) {
+func callSyncHook(cc *v1alpha1.CompositeController, poster common.Poster, request *syncHookRequest) (*syncHookResponse, error) {
 	if cc.Spec.Hooks == nil || cc.Spec.Hooks.Sync == nil {
 		return nil, fmt.Errorf("sync hook not defined")
 	}
 	var response syncHookResponse
-	if err := hooks.Call(cc.Spec.Hooks.Sync, request, &response); err != nil {
+	if err := hooks.Call(cc.Spec.Hooks.Sync, poster, request, &response); err != nil {
 		return nil, fmt.Errorf("sync hook failed: %v", err)
 	}
 	return &response, nil

--- a/controller/composite/metacontroller.go
+++ b/controller/composite/metacontroller.go
@@ -54,9 +54,11 @@ type Metacontroller struct {
 	parentControllers map[string]*parentController
 
 	stopCh, doneCh chan struct{}
+
+	poster common.Poster
 }
 
-func NewMetacontroller(resources *dynamicdiscovery.ResourceMap, dynClient *dynamicclientset.Clientset, dynInformers *dynamicinformer.SharedInformerFactory, mcInformerFactory mcinformers.SharedInformerFactory, mcClient mcclientset.Interface) *Metacontroller {
+func NewMetacontroller(resources *dynamicdiscovery.ResourceMap, dynClient *dynamicclientset.Clientset, dynInformers *dynamicinformer.SharedInformerFactory, mcInformerFactory mcinformers.SharedInformerFactory, mcClient mcclientset.Interface, poster common.Poster) *Metacontroller {
 	mc := &Metacontroller{
 		resources:    resources,
 		mcClient:     mcClient,
@@ -70,6 +72,8 @@ func NewMetacontroller(resources *dynamicdiscovery.ResourceMap, dynClient *dynam
 
 		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CompositeController"),
 		parentControllers: make(map[string]*parentController),
+
+		poster: poster,
 	}
 
 	mc.ccInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -175,7 +179,7 @@ func (mc *Metacontroller) syncCompositeController(cc *v1alpha1.CompositeControll
 		delete(mc.parentControllers, cc.Name)
 	}
 
-	pc, err := newParentController(mc.resources, mc.dynClient, mc.dynInformers, mc.mcClient, mc.revisionLister, cc)
+	pc, err := newParentController(mc.resources, mc.dynClient, mc.dynInformers, mc.mcClient, mc.revisionLister, cc, mc.poster)
 	if err != nil {
 		return err
 	}

--- a/controller/decorator/controller.go
+++ b/controller/decorator/controller.go
@@ -62,9 +62,11 @@ type decoratorController struct {
 
 	parentInformers common.InformerMap
 	childInformers  common.InformerMap
+
+	poster common.Poster
 }
 
-func newDecoratorController(resources *dynamicdiscovery.ResourceMap, dynClient *dynamicclientset.Clientset, dynInformers *dynamicinformer.SharedInformerFactory, dc *v1alpha1.DecoratorController) (controller *decoratorController, newErr error) {
+func newDecoratorController(resources *dynamicdiscovery.ResourceMap, dynClient *dynamicclientset.Clientset, dynInformers *dynamicinformer.SharedInformerFactory, dc *v1alpha1.DecoratorController, poster common.Poster) (controller *decoratorController, newErr error) {
 	c := &decoratorController{
 		dc:              dc,
 		resources:       resources,
@@ -74,6 +76,8 @@ func newDecoratorController(resources *dynamicdiscovery.ResourceMap, dynClient *
 		childInformers:  make(common.InformerMap),
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DecoratorController-"+dc.Name),
+
+		poster: poster,
 	}
 
 	var err error
@@ -420,7 +424,7 @@ func (c *decoratorController) syncParentObject(parent *unstructured.Unstructured
 		Object:      parent,
 		Attachments: observedChildren,
 	}
-	syncResult, err := callSyncHook(c.dc, syncRequest)
+	syncResult, err := callSyncHook(c.dc, c.poster, syncRequest)
 	if err != nil {
 		return err
 	}

--- a/controller/decorator/hooks.go
+++ b/controller/decorator/hooks.go
@@ -39,12 +39,12 @@ type syncHookResponse struct {
 	Attachments []*unstructured.Unstructured `json:"attachments"`
 }
 
-func callSyncHook(dc *v1alpha1.DecoratorController, request *syncHookRequest) (*syncHookResponse, error) {
+func callSyncHook(dc *v1alpha1.DecoratorController, poster common.Poster, request *syncHookRequest) (*syncHookResponse, error) {
 	if dc.Spec.Hooks == nil || dc.Spec.Hooks.Sync == nil {
 		return nil, fmt.Errorf("sync hook not defined")
 	}
 	var response syncHookResponse
-	if err := hooks.Call(dc.Spec.Hooks.Sync, request, &response); err != nil {
+	if err := hooks.Call(dc.Spec.Hooks.Sync, poster, request, &response); err != nil {
 		return nil, fmt.Errorf("sync hook failed: %v", err)
 	}
 	return &response, nil

--- a/controller/decorator/metacontroller.go
+++ b/controller/decorator/metacontroller.go
@@ -50,9 +50,11 @@ type Metacontroller struct {
 	decoratorControllers map[string]*decoratorController
 
 	stopCh, doneCh chan struct{}
+
+	poster common.Poster
 }
 
-func NewMetacontroller(resources *dynamicdiscovery.ResourceMap, dynClient *dynamicclientset.Clientset, dynInformers *dynamicinformer.SharedInformerFactory, mcInformerFactory mcinformers.SharedInformerFactory) *Metacontroller {
+func NewMetacontroller(resources *dynamicdiscovery.ResourceMap, dynClient *dynamicclientset.Clientset, dynInformers *dynamicinformer.SharedInformerFactory, mcInformerFactory mcinformers.SharedInformerFactory, poster common.Poster) *Metacontroller {
 	mc := &Metacontroller{
 		resources:    resources,
 		dynClient:    dynClient,
@@ -63,6 +65,8 @@ func NewMetacontroller(resources *dynamicdiscovery.ResourceMap, dynClient *dynam
 
 		queue:                workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DecoratorController"),
 		decoratorControllers: make(map[string]*decoratorController),
+
+		poster: poster,
 	}
 
 	mc.dcInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -168,7 +172,7 @@ func (mc *Metacontroller) syncDecoratorController(dc *v1alpha1.DecoratorControll
 		delete(mc.decoratorControllers, dc.Name)
 	}
 
-	c, err := newDecoratorController(mc.resources, mc.dynClient, mc.dynInformers, dc)
+	c, err := newDecoratorController(mc.resources, mc.dynClient, mc.dynInformers, dc, mc.poster)
 	if err != nil {
 		return err
 	}

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -20,11 +20,12 @@ import (
 	"fmt"
 
 	"k8s.io/metacontroller/apis/metacontroller/v1alpha1"
+	"k8s.io/metacontroller/controller/common"
 )
 
-func Call(hook *v1alpha1.Hook, request interface{}, response interface{}) error {
+func Call(hook *v1alpha1.Hook, poster common.Poster, request interface{}, response interface{}) error {
 	if hook.Webhook != nil {
-		return callWebhook(hook.Webhook, request, response)
+		return callWebhook(hook.Webhook, poster, request, response)
 	}
 	return fmt.Errorf("hook spec not defined")
 }

--- a/hooks/webhook.go
+++ b/hooks/webhook.go
@@ -22,19 +22,15 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"time"
 
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/json"
 
 	"k8s.io/metacontroller/apis/metacontroller/v1alpha1"
+	"k8s.io/metacontroller/controller/common"
 )
 
-const (
-	hookTimeout = 10 * time.Second
-)
-
-func callWebhook(webhook *v1alpha1.Webhook, request interface{}, response interface{}) error {
+func callWebhook(webhook *v1alpha1.Webhook, poster common.Poster, request interface{}, response interface{}) error {
 	url, err := webhookURL(webhook)
 	if err != nil {
 		return err
@@ -51,8 +47,7 @@ func callWebhook(webhook *v1alpha1.Webhook, request interface{}, response interf
 	}
 
 	// Send request.
-	client := &http.Client{Timeout: hookTimeout}
-	resp, err := client.Post(url, "application/json", bytes.NewReader(reqBody))
+	resp, err := poster.Post(url, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return fmt.Errorf("http error: %v", err)
 	}


### PR DESCRIPTION
I generally run all my services inside the cluster with certificates signed by an internal CA. I want to run my metacontroller hooks the same way.  This PR adds a flag to allow adding a custom CA for certificate verification.

I wound up having to touch a lot more code that I liked. Ultimately, I needed to use a custom `http.Client` in `hooks/webhook.go`, but I need to pass that through from `main.go`. I'm not sure this is the best approach, but wanted to offer it up for discussion.

Thanks for the project! This allowed me to greatly simplify some custom controllers I maintain at my day job.