### PR TITLE
Add user-defined webhook timeout

### DIFF
--- a/apis/metacontroller/v1alpha1/types.go
+++ b/apis/metacontroller/v1alpha1/types.go
@@ -108,7 +108,7 @@ type Hook struct {
 
 type Webhook struct {
 	URL *string `json:"url,omitempty"`
-	TimeoutSeconds *int32 `json:"timeoutSeconds,omitempty"`
+	Timeout *metav1.Duration `json:"timeout,omitempty"`
 
 	Path    *string           `json:"path,omitempty"`
 	Service *ServiceReference `json:"service,omitempty"`

--- a/apis/metacontroller/v1alpha1/types.go
+++ b/apis/metacontroller/v1alpha1/types.go
@@ -108,6 +108,7 @@ type Hook struct {
 
 type Webhook struct {
 	URL *string `json:"url,omitempty"`
+	TimeoutSeconds *int32 `json:"timeoutSeconds,omitempty"`
 
 	Path    *string           `json:"path,omitempty"`
 	Service *ServiceReference `json:"service,omitempty"`

--- a/docs/_api/compositecontroller.md
+++ b/docs/_api/compositecontroller.md
@@ -371,5 +371,5 @@ sent to [`kubectl apply`][kubectl apply].
 That is, you should [set only the fields that you care about](/api/apply/).
 
 Note that your webhook handler must return a response with a status code of `200`
-to be consider successful. Metacontroller will wait for a response for up to the
-amount defined in `timeout`, which defaults to `10s` if not defined explicitly.
+to be considered successful. Metacontroller will wait for a response for up to the
+amount defined in the [Webhook spec](/api/hook/#webhook).

--- a/docs/_api/compositecontroller.md
+++ b/docs/_api/compositecontroller.md
@@ -47,6 +47,7 @@ spec:
     sync:
       webhook:
         url: http://catset-controller.metacontroller/sync
+        timeoutSeconds: 10
 ```
 
 ## Spec
@@ -368,3 +369,7 @@ response because they're in different forms.
 Instead, you should think of each entry in the list of `children` as being
 sent to [`kubectl apply`][kubectl apply].
 That is, you should [set only the fields that you care about](/api/apply/).
+
+Note that your webhook handler must return a response with a status code of `200`
+to be consider successful. Metacontroller will wait for a response for up to the
+amount defined in `timeoutSeconds`, which defaults to `10` if not defined explicitly.

--- a/docs/_api/compositecontroller.md
+++ b/docs/_api/compositecontroller.md
@@ -47,7 +47,7 @@ spec:
     sync:
       webhook:
         url: http://catset-controller.metacontroller/sync
-        timeoutSeconds: 10
+        timeout: 10s
 ```
 
 ## Spec
@@ -372,4 +372,4 @@ That is, you should [set only the fields that you care about](/api/apply/).
 
 Note that your webhook handler must return a response with a status code of `200`
 to be consider successful. Metacontroller will wait for a response for up to the
-amount defined in `timeoutSeconds`, which defaults to `10` if not defined explicitly.
+amount defined in `timeout`, which defaults to `10s` if not defined explicitly.

--- a/docs/_api/decoratorcontroller.md
+++ b/docs/_api/decoratorcontroller.md
@@ -36,7 +36,7 @@ spec:
     sync:
       webhook:
         url: http://service-per-pod.metacontroller/sync-service-per-pod
-        timeoutSeconds: 10
+        timeout: 10s
 ```
 
 ## Spec
@@ -307,4 +307,4 @@ That is, you should [set only the fields that you care about](/api/apply/).
 
 Note that your webhook handler must return a response with a status code of `200`
 to be consider successful. Metacontroller will wait for a response for up to the
-amount defined in `timeoutSeconds`, which defaults to `10` if not defined explicitly.
+amount defined in `timeout`, which defaults to `10s` if not defined explicitly.

--- a/docs/_api/decoratorcontroller.md
+++ b/docs/_api/decoratorcontroller.md
@@ -306,5 +306,5 @@ sent to [`kubectl apply`][kubectl apply].
 That is, you should [set only the fields that you care about](/api/apply/).
 
 Note that your webhook handler must return a response with a status code of `200`
-to be consider successful. Metacontroller will wait for a response for up to the
-amount defined in `timeout`, which defaults to `10s` if not defined explicitly.
+to be considered successful. Metacontroller will wait for a response for up to the
+amount defined in the [Webhook spec](/api/hook/#webhook).

--- a/docs/_api/decoratorcontroller.md
+++ b/docs/_api/decoratorcontroller.md
@@ -36,6 +36,7 @@ spec:
     sync:
       webhook:
         url: http://service-per-pod.metacontroller/sync-service-per-pod
+        timeoutSeconds: 10
 ```
 
 ## Spec
@@ -303,3 +304,7 @@ response because they're in different forms.
 Instead, you should think of each entry in the list of `attachments` as being
 sent to [`kubectl apply`][kubectl apply].
 That is, you should [set only the fields that you care about](/api/apply/).
+
+Note that your webhook handler must return a response with a status code of `200`
+to be consider successful. Metacontroller will wait for a response for up to the
+amount defined in `timeoutSeconds`, which defaults to `10` if not defined explicitly.

--- a/docs/_api/hook.md
+++ b/docs/_api/hook.md
@@ -25,7 +25,7 @@ Each Webhook has the following fields:
 | Field | Description |
 | ----- | ----------- |
 | url | A full URL for the webhook (e.g. `http://my-controller-svc/hook`). If present, this overrides any values provided for `path` and `service`. |
-| timeout | A duration indicating the time that Metacontroller should wait for a response. If the webhook takes longer than this time, the webhook call is aborted and retried later. Defaults to 10s. |
+| timeout | A duration (in the format of Go's time.Duration) indicating the time that Metacontroller should wait for a response. If the webhook takes longer than this time, the webhook call is aborted and retried later. Defaults to 10s. |
 | path | A path to be appended to the accompanying `service` to reach this hook (e.g. `/hook`). Ignored if full `url` is specified. |
 | [service](#service-reference) | A reference to a Kubernetes Service through which this hook can be reached. |
 

--- a/docs/_api/hook.md
+++ b/docs/_api/hook.md
@@ -25,7 +25,7 @@ Each Webhook has the following fields:
 | Field | Description |
 | ----- | ----------- |
 | url | A full URL for the webhook (e.g. `http://my-controller-svc/hook`). If present, this overrides any values provided for `path` and `service`. |
-| timeoutSeconds | An integer indicating the number of seconds that Metacontroller should wait for a response. If the webhook takes longer than this time, the webhook call is aborted and retried later. Defaults to 10 seconds. |
+| timeout | A duration indicating the time that Metacontroller should wait for a response. If the webhook takes longer than this time, the webhook call is aborted and retried later. Defaults to 10s. |
 | path | A path to be appended to the accompanying `service` to reach this hook (e.g. `/hook`). Ignored if full `url` is specified. |
 | [service](#service-reference) | A reference to a Kubernetes Service through which this hook can be reached. |
 

--- a/docs/_api/hook.md
+++ b/docs/_api/hook.md
@@ -25,6 +25,7 @@ Each Webhook has the following fields:
 | Field | Description |
 | ----- | ----------- |
 | url | A full URL for the webhook (e.g. `http://my-controller-svc/hook`). If present, this overrides any values provided for `path` and `service`. |
+| timeoutSeconds | An integer indicating the number of seconds that Metacontroller should wait for a response. If the webhook takes longer than this time, the webhook call is aborted and retried later. Defaults to 10 seconds. |
 | path | A path to be appended to the accompanying `service` to reach this hook (e.g. `/hook`). Ignored if full `url` is specified. |
 | [service](#service-reference) | A reference to a Kubernetes Service through which this hook can be reached. |
 

--- a/hooks/webhook.go
+++ b/hooks/webhook.go
@@ -101,17 +101,15 @@ func webhookURL(webhook *v1alpha1.Webhook) (string, error) {
 }
 
 func webhookTimeout(webhook *v1alpha1.Webhook) (time.Duration, error) {
-	zero := time.Duration(0)
-
 	if webhook.Timeout == nil {
 		// Defaults to 10 Seconds to preserve current behavior.
 		return 10 * time.Second, nil
 	}
 
-	if (*webhook.Timeout).Duration <= zero {
+	if webhook.Timeout.Duration <= 0 {
 		// Defaults to 10 Seconds if invalid.
 		return 10 * time.Second, fmt.Errorf("invalid client config: timeout must be a non-zero positive duration")
 	}
 
-	return (*webhook.Timeout).Duration, nil
+	return webhook.Timeout.Duration, nil
 }

--- a/hooks/webhook.go
+++ b/hooks/webhook.go
@@ -49,6 +49,7 @@ func callWebhook(webhook *v1alpha1.Webhook, request interface{}, response interf
 
 	// Send request.
 	client := &http.Client{Timeout: hookTimeout}
+	glog.V(6).Infof("DEBUG: webhook timeout: %v", hookTimeout)
 	resp, err := client.Post(url, "application/json", bytes.NewReader(reqBody))
 	if err != nil {
 		return fmt.Errorf("http error: %v", err)
@@ -100,15 +101,17 @@ func webhookURL(webhook *v1alpha1.Webhook) (string, error) {
 }
 
 func webhookTimeout(webhook *v1alpha1.Webhook) (time.Duration, error) {
-	if webhook.TimeoutSeconds != nil {
+	zero := time.Duration(0)
+
+	if webhook.Timeout == nil {
 		// Defaults to 10 Seconds to preserve current behavior.
 		return 10 * time.Second, nil
 	}
 
-	if *webhook.TimeoutSeconds <= 0 {
+	if (*webhook.Timeout).Duration <= zero {
 		// Defaults to 10 Seconds if invalid.
-		return 10 * time.Second, fmt.Errorf("invalid client config: timeoutSecons must be a non-zero positive integer")
+		return 10 * time.Second, fmt.Errorf("invalid client config: timeout must be a non-zero positive duration")
 	}
 
-	return time.Duration(*webhook.TimeoutSeconds) * time.Second, nil
+	return (*webhook.Timeout).Duration, nil
 }


### PR DESCRIPTION
Fixes #54

### Adds: 
- User defined timeout for sync webhooks, defaults to current behavior.
- Documentation.

_Note that I have not tested this PR as I'm still figuring out how to setup the build environment properly._ 