### PR TITLE
Add Skaffold+Kustomize config for development.

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,11 @@
+# This is the same as Dockerfile, but skips `dep ensure`.
+# It assumes you already ran that locally.
+FROM golang:1.10 AS build
+
+COPY . /go/src/k8s.io/metacontroller/
+WORKDIR /go/src/k8s.io/metacontroller/
+RUN go install
+
+FROM debian:stretch-slim
+COPY --from=build /go/bin/metacontroller /usr/bin/
+CMD ["/usr/bin/metacontroller"]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -360,6 +360,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fdbec0c5912ed167cca55e35fd6e9b2d440b64be6f7784c32938cf126fcf8a1e"
+  inputs-digest = "0a0f93a3564fe03b9b3bc39120f999037c0994cdc70859abb6b6a8b39553119a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TAG = 0.3
+TAG = dev
 
 PKG        := k8s.io/metacontroller
 API_GROUPS := metacontroller/v1alpha1

--- a/docs/_contrib/build.md
+++ b/docs/_contrib/build.md
@@ -37,6 +37,32 @@ dep ensure
 go install
 ```
 
+## Skaffold Build
+
+If you're working on changes to Metacontroller itself, you can use
+[Skaffold][] and [Kustomize][] to make iterating more fluid.
+
+First use `dep` as described in the [Local Build](#local-build) section to
+populate the `vendor` directory.
+Rather than running `dep ensure` on every build, the development version of the
+Dockerfile expects you to have already run `dep ensure` locally.
+
+Next make sure your local Docker client is signed in to push to Docker Hub.
+Then change `enisoc/metacontroller` to point to `<yourname>/metacontroller`
+in these files:
+
+* `skaffold.yaml`
+* `manifests/dev/image.yaml`
+
+Now you can build and deploy your latest changes with:
+
+```sh
+skaffold run
+```
+
+[skaffold]: https://github.com/GoogleContainerTools/skaffold
+[kustomize]: https://github.com/kubernetes-sigs/kustomize
+
 ## Generated Files
 
 If you make changes to the [Metacontroller API types]({{ site.repo_dir }}/apis/metacontroller/),

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,8 @@
+commonLabels:
+  app: metacontroller
+resources:
+- manifests/metacontroller-rbac.yaml
+- manifests/metacontroller.yaml
+patches:
+- manifests/dev/image.yaml
+- manifests/dev/args.yaml

--- a/manifests/dev/args.yaml
+++ b/manifests/dev/args.yaml
@@ -1,0 +1,15 @@
+# Override args for development mode.
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: metacontroller
+  namespace: metacontroller
+spec:
+  template:
+    spec:
+      containers:
+      - name: metacontroller
+        args:
+        - --logtostderr
+        - -v=5
+        - --discovery-interval=5s

--- a/manifests/dev/image.yaml
+++ b/manifests/dev/image.yaml
@@ -1,0 +1,12 @@
+# Override image for development mode (skaffold fills in the tag).
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: metacontroller
+  namespace: metacontroller
+spec:
+  template:
+    spec:
+      containers:
+      - name: metacontroller
+        image: enisoc/metacontroller

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -64,9 +64,8 @@ spec:
       containers:
       - name: metacontroller
         image: metacontroller/metacontroller:0.2
-        imagePullPolicy: Always
         command: ["/usr/bin/metacontroller"]
         args:
         - --logtostderr
         - -v=4
-        - --discovery-interval=10s
+        - --discovery-interval=20s

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,9 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  artifacts:
+  - imageName: enisoc/metacontroller
+    docker:
+      dockerfilePath: Dockerfile.dev
+deploy:
+  kustomize: {}


### PR DESCRIPTION
This lets us keep the files in `manifests/` pinned to release tags and non-debug args.