### PR TITLE
Add .dockerignore file.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Ignoring things that aren't needed to build the Docker image
+# helps Skaffold know when not to rebuild the image.
+docs
+examples
+manifests


### PR DESCRIPTION
Ignoring things that aren't needed to build the Docker image helps Skaffold know when not to rebuild the image.