### PR TITLE
README: add note to vendor as k8s.io/metacontroller

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ the add-on works the same in any Kubernetes cluster.
 
 Please see the [documentation site](https://metacontroller.app) for details.
 
+Note: Vendor this package as `k8s.io/metacontroller`.
+
 ## Contact
 
 Please file [GitHub issues](issues) for bugs, feature requests, and proposals.


### PR DESCRIPTION
Because of `k8s.io/metacontroller` is used as the import path [everywhere](https://github.com/GoogleCloudPlatform/metacontroller/search?q=%22k8s.io%2Fmetacontroller%22&unscoped_q=%22k8s.io%2Fmetacontroller%22).

