### PR TITLE
only allow one Metacontroller instance to be active at a time

### DIFF
--- a/docs/_guide/install.md
+++ b/docs/_guide/install.md
@@ -29,7 +29,7 @@ Replace `<user>` and `<domain>` above based on the account you use to authentica
 ```sh
 # Create 'metacontroller' namespace, service account, and role/binding.
 kubectl apply -f {{ site.repo_raw }}/manifests/metacontroller-rbac.yaml
-# Create CRDs for Metacontroller APIs, and the Metacontroller Deployment.
+# Create CRDs for Metacontroller APIs, and the Metacontroller StatefulSet.
 kubectl apply -f {{ site.repo_raw }}/manifests/metacontroller.yaml
 ```
 
@@ -39,7 +39,7 @@ If you prefer to build and host your own images, please see the
 ## Configuration
 
 The Metacontroller server has a few settings that can be configured
-with command-line flags (by editing the Metacontroller Deployment
+with command-line flags (by editing the Metacontroller StatefulSet
 in `manifests/metacontroller.yaml`):
 
 | Flag | Description |

--- a/examples/catset/test.sh
+++ b/examples/catset/test.sh
@@ -12,27 +12,29 @@ trap cleanup EXIT
 
 set -ex
 
+cs="catsets"
+
 echo "Install controller..."
 kubectl create configmap catset-controller -n metacontroller --from-file=sync.js
 kubectl apply -f catset-controller.yaml
 
 echo "Wait until CRD is available..."
-until kubectl get catsets; do sleep 1; done
+until kubectl get $cs; do sleep 1; done
 
 echo "Create an object..."
 kubectl apply -f my-catset.yaml
 
 echo "Wait for 3 Pods to be Ready..."
-until [[ "$(kubectl get cs nginx-backend -o 'jsonpath={.status.readyReplicas}')" -eq 3 ]]; do sleep 1; done
+until [[ "$(kubectl get $cs nginx-backend -o 'jsonpath={.status.readyReplicas}')" -eq 3 ]]; do sleep 1; done
 
 echo "Scale up to 4 replicas..."
-kubectl patch catset nginx-backend --type=merge -p '{"spec":{"replicas":4}}'
+kubectl patch $cs nginx-backend --type=merge -p '{"spec":{"replicas":4}}'
 
 echo "Wait for 4 Pods to be Ready..."
-until [[ "$(kubectl get cs nginx-backend -o 'jsonpath={.status.readyReplicas}')" -eq 4 ]]; do sleep 1; done
+until [[ "$(kubectl get $cs nginx-backend -o 'jsonpath={.status.readyReplicas}')" -eq 4 ]]; do sleep 1; done
 
 echo "Scale down to 2 replicas..."
-kubectl patch catset nginx-backend --type=merge -p '{"spec":{"replicas":2}}'
+kubectl patch $cs nginx-backend --type=merge -p '{"spec":{"replicas":2}}'
 
 echo "Wait for 2 Pods to be Ready..."
-until [[ "$(kubectl get cs nginx-backend -o 'jsonpath={.status.readyReplicas}')" -eq 2 ]]; do sleep 1; done
+until [[ "$(kubectl get $cs nginx-backend -o 'jsonpath={.status.readyReplicas}')" -eq 2 ]]; do sleep 1; done

--- a/examples/indexedjob/test.sh
+++ b/examples/indexedjob/test.sh
@@ -12,18 +12,20 @@ trap cleanup EXIT
 
 set -ex
 
+ij="indexedjobs"
+
 echo "Install controller..."
 kubectl create configmap indexedjob-controller -n metacontroller --from-file=sync.py
 kubectl apply -f indexedjob-controller.yaml
 
 echo "Wait until CRD is available..."
-until kubectl get indexedjobs; do sleep 1; done
+until kubectl get $ij; do sleep 1; done
 
 echo "Create an object..."
 kubectl apply -f my-indexedjob.yaml
 
 echo "Wait for 10 successful completions..."
-until [[ "$(kubectl get indexedjob print-index -o 'jsonpath={.status.succeeded}')" -eq 10 ]]; do sleep 1; done
+until [[ "$(kubectl get $ij print-index -o 'jsonpath={.status.succeeded}')" -eq 10 ]]; do sleep 1; done
 
 echo "Check that correct index is printed..."
 if [[ "$(kubectl logs print-index-9)" != "9" ]]; then

--- a/manifests/dev/args.yaml
+++ b/manifests/dev/args.yaml
@@ -1,6 +1,6 @@
 # Override args for development mode.
-apiVersion: apps/v1beta1
-kind: Deployment
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/manifests/dev/args.yaml
+++ b/manifests/dev/args.yaml
@@ -5,6 +5,7 @@ metadata:
   name: metacontroller
   namespace: metacontroller
 spec:
+  serviceName: ""
   template:
     spec:
       containers:

--- a/manifests/dev/args.yaml
+++ b/manifests/dev/args.yaml
@@ -1,5 +1,5 @@
 # Override args for development mode.
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
   name: metacontroller

--- a/manifests/dev/args.yaml
+++ b/manifests/dev/args.yaml
@@ -5,7 +5,6 @@ metadata:
   name: metacontroller
   namespace: metacontroller
 spec:
-  serviceName: ""
   template:
     spec:
       containers:

--- a/manifests/dev/image.yaml
+++ b/manifests/dev/image.yaml
@@ -5,6 +5,7 @@ metadata:
   name: metacontroller
   namespace: metacontroller
 spec:
+  serviceName: ""
   template:
     spec:
       containers:

--- a/manifests/dev/image.yaml
+++ b/manifests/dev/image.yaml
@@ -1,6 +1,6 @@
 # Override image for development mode (skaffold fills in the tag).
-apiVersion: apps/v1beta1
-kind: Deployment
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: metacontroller
   namespace: metacontroller

--- a/manifests/dev/image.yaml
+++ b/manifests/dev/image.yaml
@@ -1,5 +1,5 @@
 # Override image for development mode (skaffold fills in the tag).
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
   name: metacontroller

--- a/manifests/dev/image.yaml
+++ b/manifests/dev/image.yaml
@@ -5,7 +5,6 @@ metadata:
   name: metacontroller
   namespace: metacontroller
 spec:
-  serviceName: ""
   template:
     spec:
       containers:

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -43,7 +43,7 @@ spec:
     singular: controllerrevision
     kind: ControllerRevision
 ---
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: StatefulSet
 metadata:
   name: metacontroller

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -55,6 +55,7 @@ spec:
   selector:
     matchLabels:
       app: metacontroller
+  serviceName: ""
   template:
     metadata:
       labels:

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -43,8 +43,8 @@ spec:
     singular: controllerrevision
     kind: ControllerRevision
 ---
-apiVersion: apps/v1beta1
-kind: Deployment
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: metacontroller
   namespace: metacontroller


### PR DESCRIPTION
Addressing issue #5 partially. In the long run, we still have to resolve leader election issue when the user spawns more than one Metacontroller instance.

Metacontroller uses `apps/v1beta1 Deployment` under the hood. This PR changes the Metacontroller to use `apps/v1beta2 StatefulSet` to maintain the invariant of only one Metacontroller instance is active at a time.