### PR TITLE
install ca-certificates in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN dep ensure && go install
 
 FROM debian:stretch-slim
 COPY --from=build /go/bin/metacontroller /usr/bin/
+RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
 CMD ["/usr/bin/metacontroller"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,4 +8,5 @@ RUN go install
 
 FROM debian:stretch-slim
 COPY --from=build /go/bin/metacontroller /usr/bin/
+RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
 CMD ["/usr/bin/metacontroller"]


### PR DESCRIPTION
This CL updates both the `Dockerfile` and `Dockerfile.dev` to install
the `ca-certificates` package in the final docker image.

closes: #86