### PR TITLE
Simpify ResourceClient namespace handling.

### DIFF
--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -73,9 +73,16 @@ func (m ChildMap) FindGroupKindName(apiGroup, kind, name string) *unstructured.U
 func relativeName(parent metav1.Object, child *unstructured.Unstructured) string {
 	if parent.GetNamespace() == "" && child.GetNamespace() != "" {
 		return fmt.Sprintf("%s/%s", child.GetNamespace(), child.GetName())
-	} else {
-		return child.GetName()
 	}
+	return child.GetName()
+}
+
+// describeObject returns a human-readable string to identify a given object.
+func describeObject(obj *unstructured.Unstructured) string {
+	if ns := obj.GetNamespace(); ns != "" {
+		return fmt.Sprintf("%s %s/%s", obj.GetKind(), ns, obj.GetName())
+	}
+	return fmt.Sprintf("%s %s", obj.GetKind(), obj.GetName())
 }
 
 // ReplaceChild replaces the child object with the same name & namespace as

--- a/controller/composite/controller.go
+++ b/controller/composite/controller.go
@@ -70,7 +70,7 @@ func newParentController(resources *dynamicdiscovery.ResourceMap, dynClient *dyn
 	if err != nil {
 		return nil, err
 	}
-	parentResource := parentClient.APIResource()
+	parentResource := parentClient.APIResource
 
 	updateStrategy, err := makeUpdateStrategyMap(resources, cc)
 	if err != nil {
@@ -508,17 +508,17 @@ func (pc *parentController) claimChildren(parent *unstructured.Unstructured) (co
 		}
 		all, err := informer.Lister().ListNamespace(namespace, labels.Everything())
 		if err != nil {
-			return nil, fmt.Errorf("can't list %v children: %v", childClient.Kind(), err)
+			return nil, fmt.Errorf("can't list %v children: %v", childClient.Kind, err)
 		}
 
 		// Always include the requested groups, even if there are no entries.
-		childMap.InitGroup(child.APIVersion, childClient.Kind())
+		childMap.InitGroup(child.APIVersion, childClient.Kind)
 
 		// Handle orphan/adopt and filter by owner+selector.
 		crm := dynamiccontrollerref.NewUnstructuredManager(childClient, parent, selector, parentGVK, childClient.GroupVersionKind(), canAdoptFunc)
 		children, err := crm.ClaimChildren(all)
 		if err != nil {
-			return nil, fmt.Errorf("can't claim %v children: %v", childClient.Kind(), err)
+			return nil, fmt.Errorf("can't claim %v children: %v", childClient.Kind, err)
 		}
 
 		// Add children to map by name.
@@ -535,7 +535,7 @@ func (pc *parentController) updateParentStatus(parent *unstructured.Unstructured
 	// We can't use Patch() because we need to ensure that the UID matches.
 	// TODO(enisoc): Use /status subresource when that exists.
 	// TODO(enisoc): Update status.observedGeneration when spec.generation starts working.
-	return pc.parentClient.Namespace(parent.GetNamespace()).UpdateWithRetries(parent, func(obj *unstructured.Unstructured) bool {
+	return pc.parentClient.Namespace(parent.GetNamespace()).AtomicUpdate(parent, func(obj *unstructured.Unstructured) bool {
 		oldStatus := k8s.GetNestedField(obj.UnstructuredContent(), "status")
 		if reflect.DeepEqual(oldStatus, status) {
 			// Nothing to do.

--- a/dynamic/discovery/discovery.go
+++ b/dynamic/discovery/discovery.go
@@ -48,7 +48,11 @@ func (r *APIResource) GroupVersionKind() schema.GroupVersionKind {
 }
 
 func (r *APIResource) GroupVersionResource() schema.GroupVersionResource {
-	return r.GroupVersion().WithResource(r.APIResource.Name)
+	return r.GroupVersion().WithResource(r.Name)
+}
+
+func (r *APIResource) GroupResource() schema.GroupResource {
+	return schema.GroupResource{Group: r.Group, Resource: r.Name}
 }
 
 type groupVersionEntry struct {


### PR DESCRIPTION
The main goal is to remove the duplication caused by introducing `NamespacedResourceClient`, because I want to add more methods similar to UpdateWithRetries as part of the work on finalizers, and I don't want to have to make extra wrappers for every new method.

We introduced `NamespacedResourceClient` to preserve the expected semantic from the generated clients that you can't chain calls to `.Namespace()`. However, given the dynamic nature of ResourceClient, I think it's simpler if we just keep the one type and allow chaining.

As part of that, I added a check that makes calling `.Namespace()` revert to a cluster-scoped client if the given namespace is empty, or if we know from discovery info that the resource is cluster-scoped. This makes it safer to just always call `Namespace()` throughout, and it will just do the right thing for either cluster-scoped or namespace-scoped resources.

I also renamed UpdateWithRetries to AtomicUpdate and added comments to clarify what it's for, and cleaned up some places where we now need to deal with objects that may or may not have namespaces.