### PR TITLE
add scope on crd spec from guide / Create a Controller

### DIFF
--- a/docs/_guide/create.md
+++ b/docs/_guide/create.md
@@ -51,6 +51,7 @@ spec:
     kind: HelloWorld
     plural: helloworlds
     singular: helloworld
+  scope: Namespaced
 ```
 
 Then apply it to your cluster:


### PR DESCRIPTION
CRD helloworlds.example.com spec needs 'scope' on spec. without scope:

`error: error validating "crd.yaml": error validating data: ValidationError(CustomResourceDefinition.spec): missing required field "scope" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec; if you choose to ignore these errors, turn validation off with --validate=false
`