### PR TITLE
Dockerfile: Improve use of cached layers during rebuild.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ WORKDIR /go/src/k8s.io/metacontroller/
 RUN dep ensure && go install
 
 FROM debian:stretch-slim
-COPY --from=build /go/bin/metacontroller /usr/bin/
 RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=build /go/bin/metacontroller /usr/bin/
 CMD ["/usr/bin/metacontroller"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,6 +7,6 @@ WORKDIR /go/src/k8s.io/metacontroller/
 RUN go install
 
 FROM debian:stretch-slim
-COPY --from=build /go/bin/metacontroller /usr/bin/
 RUN apt-get update && apt-get install --no-install-recommends -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=build /go/bin/metacontroller /usr/bin/
 CMD ["/usr/bin/metacontroller"]


### PR DESCRIPTION
Install packages before copying in the new binary, so it doesn't reinstall
the packages every time the binary changes.