### PR TITLE
Add flag to configure client for remote API server.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -129,6 +129,14 @@
   version = "v0.5.0"
 
 [[projects]]
+  digest = "1:8eb1de8112c9924d59bf1d3e5c26f5eaa2bfc2a5fcbb92dc1c2e4546d695f277"
+  name = "github.com/imdario/mergo"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
+  version = "v0.3.6"
+
+[[projects]]
   digest = "1:3e551bbb3a7c0ab2a2bf4660e7fcad16db089fdcfbb44b0199e62838038623ea"
   name = "github.com/json-iterator/go"
   packages = ["."]
@@ -427,7 +435,7 @@
   version = "kubernetes-1.11.0"
 
 [[projects]]
-  digest = "1:fc0de8bdfbe547fc4c1f2a2862cc2b8297e5ffe9dec45aa7c1cba6f56ad55efe"
+  digest = "1:46fdbab099bee58b273d4833b68b4f316275b72c934638e68f8ca4ee77e34788"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -440,8 +448,12 @@
     "plugin/pkg/client/auth/exec",
     "rest",
     "rest/watch",
+    "tools/auth",
     "tools/cache",
+    "tools/clientcmd",
     "tools/clientcmd/api",
+    "tools/clientcmd/api/latest",
+    "tools/clientcmd/api/v1",
     "tools/metrics",
     "tools/pager",
     "transport",
@@ -449,6 +461,7 @@
     "util/cert",
     "util/connrotation",
     "util/flowcontrol",
+    "util/homedir",
     "util/integer",
     "util/retry",
     "util/workqueue",
@@ -539,6 +552,7 @@
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/cache",
+    "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/util/flowcontrol",
     "k8s.io/client-go/util/retry",
     "k8s.io/client-go/util/workqueue",


### PR DESCRIPTION
This allows Metacontroller and webhook servers to run outside the Kubernetes cluster that they manage. However, CompositeController or DecoratorController objects still live in the same cluster as the objects being managed.

This should help unblock experimentation with out-of-cluster hosting patterns like the ones discussed in #111.