### PR TITLE
Split dev kustomization into base + dev overlay

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -3,6 +3,3 @@ commonLabels:
 resources:
 - manifests/metacontroller-rbac.yaml
 - manifests/metacontroller.yaml
-patches:
-- manifests/dev/image.yaml
-- manifests/dev/args.yaml

--- a/manifests/dev/kustomization.yaml
+++ b/manifests/dev/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../..
+patches:
+- image.yaml
+- args.yaml

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v1alpha2
+apiVersion: skaffold/v1alpha5
 kind: Config
 build:
   artifacts:
@@ -6,4 +6,5 @@ build:
     docker:
       dockerfilePath: Dockerfile.dev
 deploy:
-  kustomize: {}
+  kustomize:
+    kustomizePath: manifests/dev


### PR DESCRIPTION
This allows Kustomize users to refer to Metacontroller's base
kustomization by URL, either for installation:

    $ kustomize build github.com/GoogleCloudPlatform/metacontroller?ref=v0.4.0 | kubectl apply -f -

Or as a base in their own overlays:

```yaml
bases:
- github.com/GoogleCloudPlatform/metacontroller?ref=v0.4.0
```

(P.S. Thanks for Metacontroller!!)