### PR TITLE
bugfix for finalizers to run

### DIFF
--- a/controller/composite/controller.go
+++ b/controller/composite/controller.go
@@ -243,7 +243,9 @@ func (pc *parentController) updateParentObject(old, cur interface{}) {
 	// but the spec hasn't changed (e.g. our own status updates).
 	oldParent := old.(*unstructured.Unstructured)
 	curParent := cur.(*unstructured.Unstructured)
-	if curParent.GetResourceVersion() != oldParent.GetResourceVersion() {
+	if curParent.GetDeletionTimestamp() == nil &&
+		oldParent.GetDeletionTimestamp() == nil &&
+		curParent.GetResourceVersion() != oldParent.GetResourceVersion() {
 		oldSpec := k8s.GetNestedField(oldParent.UnstructuredContent(), "spec")
 		curSpec := k8s.GetNestedField(curParent.UnstructuredContent(), "spec")
 		if reflect.DeepEqual(oldSpec, curSpec) {


### PR DESCRIPTION
Bugfix for observed behavior where CompositeController finalizers do not run, in kubernetes v1.10.8.

The `updateParentObject()` method ignores updates when the resource version and spec haven't changed.  However, `kubectl delete` , when finalizers are present, will add `deletionTimestamp`, but will not modify the resource version or the spec.   So finalizers do not run.

This PR changes `updateParentObject()` to always process updates if they contain a deletion timestamp, so that the finalizers run.

Fixes #125