### PR TITLE
Fix deletion of namespaced children

### DIFF
--- a/controller/common/manage_children.go
+++ b/controller/common/manage_children.go
@@ -166,11 +166,15 @@ func deleteChildren(client *dynamicclientset.ResourceClient, parent *unstructure
 			// Skip objects that are already pending deletion.
 			continue
 		}
+		ns := obj.GetNamespace()
+		if ns == "" {
+			ns = parent.GetNamespace()
+		}
 		if desired == nil || desired[name] == nil {
 			// This observed object wasn't listed as desired.
 			glog.Infof("%v: deleting %v", describeObject(parent), describeObject(obj))
 			uid := obj.GetUID()
-			err := client.Namespace(obj.GetNamespace()).Delete(name, &metav1.DeleteOptions{
+			err := client.Namespace(ns).Delete(obj.GetName(), &metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{UID: &uid},
 			})
 			if err != nil {
@@ -223,7 +227,7 @@ func updateChildren(client *dynamicclientset.ResourceClient, updateStrategy Chil
 				// Delete the object (now) and recreate it (on the next sync).
 				glog.Infof("%v: deleting %v for update", describeObject(parent), describeObject(obj))
 				uid := oldObj.GetUID()
-				err := client.Namespace(ns).Delete(name, &metav1.DeleteOptions{
+				err := client.Namespace(ns).Delete(oldObj.GetName(), &metav1.DeleteOptions{
 					Preconditions: &metav1.Preconditions{UID: &uid},
 				})
 				if err != nil {


### PR DESCRIPTION
Bugfix for the deletion of namespaced child resources.

When a cluster scoped parent resource manages namespace scoped child resources, the `Delete()` method gets passed the namespaced resource name in the format `{.metadata.namespace}/{.metadata.name}` instead of just the resource name.

This results in errors of the form

```
[[ can't delete <resource> <namespace>/<resource name>: the server could not find the requested resource] the server could not find the requested resource]
```

This PR ensures that the `Delete()` functions gets passed the resource name without the namespace part.

Fixes #127