### PR TITLE
Fix deleting a ns-scoped child of a cluster-scoped controller

### DIFF
--- a/controller/common/manage_children.go
+++ b/controller/common/manage_children.go
@@ -170,7 +170,7 @@ func deleteChildren(client *dynamicclientset.ResourceClient, parent *unstructure
 			// This observed object wasn't listed as desired.
 			glog.Infof("%v: deleting %v", describeObject(parent), describeObject(obj))
 			uid := obj.GetUID()
-			err := client.Namespace(obj.GetNamespace()).Delete(name, &metav1.DeleteOptions{
+			err := client.Namespace(obj.GetNamespace()).Delete(obj.GetName(), &metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{UID: &uid},
 			})
 			if err != nil {
@@ -223,7 +223,7 @@ func updateChildren(client *dynamicclientset.ResourceClient, updateStrategy Chil
 				// Delete the object (now) and recreate it (on the next sync).
 				glog.Infof("%v: deleting %v for update", describeObject(parent), describeObject(obj))
 				uid := oldObj.GetUID()
-				err := client.Namespace(ns).Delete(name, &metav1.DeleteOptions{
+				err := client.Namespace(ns).Delete(obj.GetName(), &metav1.DeleteOptions{
 					Preconditions: &metav1.Preconditions{UID: &uid},
 				})
 				if err != nil {


### PR DESCRIPTION
Fixes #127.

I tried a build with this change in my cluster, and it was able to delete a pod created on behalf of a cluster-scoped composite controller.