### PR TITLE
Delete namespace resource from kustomize

### DIFF
--- a/controller/common/manage_children.go
+++ b/controller/common/manage_children.go
@@ -170,7 +170,7 @@ func deleteChildren(client *dynamicclientset.ResourceClient, parent *unstructure
 			// This observed object wasn't listed as desired.
 			glog.Infof("%v: deleting %v", describeObject(parent), describeObject(obj))
 			uid := obj.GetUID()
-			err := client.Namespace(obj.GetNamespace()).Delete(name, &metav1.DeleteOptions{
+			err := client.Namespace(obj.GetNamespace()).Delete(obj.GetName(), &metav1.DeleteOptions{
 				Preconditions: &metav1.Preconditions{UID: &uid},
 			})
 			if err != nil {
@@ -223,7 +223,7 @@ func updateChildren(client *dynamicclientset.ResourceClient, updateStrategy Chil
 				// Delete the object (now) and recreate it (on the next sync).
 				glog.Infof("%v: deleting %v for update", describeObject(parent), describeObject(obj))
 				uid := oldObj.GetUID()
-				err := client.Namespace(ns).Delete(name, &metav1.DeleteOptions{
+				err := client.Namespace(ns).Delete(obj.GetName(), &metav1.DeleteOptions{
 					Preconditions: &metav1.Preconditions{UID: &uid},
 				})
 				if err != nil {

--- a/controller/composite/controller.go
+++ b/controller/composite/controller.go
@@ -243,7 +243,9 @@ func (pc *parentController) updateParentObject(old, cur interface{}) {
 	// but the spec hasn't changed (e.g. our own status updates).
 	oldParent := old.(*unstructured.Unstructured)
 	curParent := cur.(*unstructured.Unstructured)
-	if curParent.GetResourceVersion() != oldParent.GetResourceVersion() {
+	if curParent.GetDeletionTimestamp() == nil &&
+		oldParent.GetDeletionTimestamp() == nil &&
+		curParent.GetResourceVersion() != oldParent.GetResourceVersion() {
 		oldSpec := k8s.GetNestedField(oldParent.UnstructuredContent(), "spec")
 		curSpec := k8s.GetNestedField(curParent.UnstructuredContent(), "spec")
 		if reflect.DeepEqual(oldSpec, curSpec) {

--- a/docs/_guide/create.md
+++ b/docs/_guide/create.md
@@ -8,8 +8,7 @@ with Metacontroller.
 
 ## Prerequisites
 
-* Kubernetes v1.8+ is recommended for the improved CRD support, especially
-  garbage collection on custom resources.
+* Kubernetes v1.9+
 * You should have `kubectl` available and configured to talk to the desired cluster.
 * You should have already [installed Metacontroller](/guide/install/).
 

--- a/docs/_guide/install.md
+++ b/docs/_guide/install.md
@@ -8,8 +8,7 @@ controllers or just to run third-party controllers that depend on it.
 
 ## Prerequisites
 
-* Kubernetes v1.8+ is recommended for the improved CRD support, especially
-  garbage collection on custom resources.
+* Kubernetes v1.9+
 * You should have `kubectl` available and configured to talk to the desired cluster.
 
 ### Grant yourself cluster-admin (GKE only)

--- a/manifests/dev/args.yaml
+++ b/manifests/dev/args.yaml
@@ -1,5 +1,5 @@
 # Override args for development mode.
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: metacontroller

--- a/manifests/dev/image.yaml
+++ b/manifests/dev/image.yaml
@@ -1,5 +1,5 @@
 # Override image for development mode (skaffold fills in the tag).
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: metacontroller

--- a/manifests/metacontroller-rbac.yaml
+++ b/manifests/metacontroller-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
   name: metacontroller
   namespace: metacontroller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metacontroller
@@ -21,7 +21,7 @@ rules:
   verbs:
   - "*"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metacontroller

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -43,7 +43,7 @@ spec:
     singular: controllerrevision
     kind: ControllerRevision
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: metacontroller

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metacontroller


### PR DESCRIPTION
Would like to use these manifests as a base for kustomize, but with my own namespace and not have the `metacontroller` namespace created. Shouldn't be necessary anyway, as most (all?) other tools will create the namespace automatically for the other resources.