### PR TITLE
Update apiVersions to v1

### DIFF
--- a/manifests/metacontroller-rbac.yaml
+++ b/manifests/metacontroller-rbac.yaml
@@ -9,7 +9,7 @@ metadata:
   name: metacontroller
   namespace: metacontroller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metacontroller
@@ -21,7 +21,7 @@ rules:
   verbs:
   - "*"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: metacontroller

--- a/manifests/metacontroller.yaml
+++ b/manifests/metacontroller.yaml
@@ -43,7 +43,7 @@ spec:
     singular: controllerrevision
     kind: ControllerRevision
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: metacontroller


### PR DESCRIPTION
`rbac.authorization.k8s.io` went v1 in K8s v1.8, StatefulSet in 1.9