### PR TITLE
Move namespace to own manifest

### DIFF
--- a/manifests/metacontroller-rbac.yaml
+++ b/manifests/metacontroller-rbac.yaml
@@ -1,9 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: metacontroller
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: metacontroller

--- a/manifests/namespace.yaml
+++ b/manifests/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metacontroller


### PR DESCRIPTION
Allows `kubectl apply -f manifests/` to create all required resources, including a `metacontroller` Namespace.

However, `kustomization.yaml` does not include that manifest in its `resources`, which lets kustomize handle namespace creation.

Replaces my borked #129.