### PR TITLE
Fix parent-child lookup for cluster-scoped parents.

### DIFF
--- a/examples/clusteredparent/test.sh
+++ b/examples/clusteredparent/test.sh
@@ -21,6 +21,13 @@ kubectl apply -f my-clusterrole.yaml
 echo "Wait for Namespaced child..."
 until [[ "$(kubectl get rolebinding -n default my-clusterrole -o 'jsonpath={.metadata.name}')" == "my-clusterrole" ]]; do sleep 1; done
 
+echo "Delete Namespaced child..."
+kubectl delete rolebinding -n default my-clusterrole --wait=true
+
+# Test that the controller with cluster-scoped parent notices the namespaced child got deleted.
+echo "Wait for Namespaced child to be recreated..."
+until [[ "$(kubectl get rolebinding -n default my-clusterrole -o 'jsonpath={.metadata.name}')" == "my-clusterrole" ]]; do sleep 1; done
+
 # Test to make sure cascading deletion of cross namespaces resources works.
 echo "Deleting ClusterRole..."
 kubectl delete -f my-clusterrole.yaml


### PR DESCRIPTION
Previously, we could assume that parent and child were always in the
same namespace. Now that we support cluster-scoped parents with
namespaced children, we need to take that into account when resolving
controllerRefs (mapping a child to its parent) and when fetching
children for a given parent.

Fixes #131