### PR TITLE
Add integration test framework and sample test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.idea/
 /vendor/
 /metacontroller
+/hack/bin/
 .*.swp
 .history

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: go
 go:
-- "1.10"
+- "1.11.x"
 go_import_path: metacontroller.app
+cache:
+  directories:
+  - vendor
+addons:
+  apt:
+    packages:
+    - wget
 install:
+- hack/get-kube-binaries.sh
 - go get -u github.com/golang/dep/cmd/dep
 - dep ensure
 script:
 # We intentionally don't generate files in CI, since we check them in.
 - go install
 - make unit-test
+- make integration-test

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -411,6 +411,19 @@
   revision = "e3c5c37695fbce2b0b46845e3bb4806c4b8faf47"
 
 [[projects]]
+  digest = "1:db049c35b74f8eeb4a14b7de4876550c24e609998fea82a54e9414691538a471"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = [
+    "pkg/apis/apiextensions",
+    "pkg/apis/apiextensions/v1beta1",
+    "pkg/client/clientset/clientset/scheme",
+    "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
+  ]
+  pruneopts = "UT"
+  revision = "3de98c57bc05a81cf463e0ad7a0af4cec8a5b510"
+  version = "kubernetes-1.11.0"
+
+[[projects]]
   digest = "1:aef7be7cede51fe9d6238dce8aeaa281aaefbfd51fd539e20be01712f1fb7383"
   name = "k8s.io/apimachinery"
   packages = [
@@ -463,12 +476,42 @@
   version = "kubernetes-1.11.0"
 
 [[projects]]
-  digest = "1:31c3daaf5b7b57ef44259ba11f90763df87f60c3289cddeda870233390f963e7"
+  digest = "1:84d71e4f41f2e03b966dcba2e3e94a653af791097984c7a7b4229bdd3baf4111"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "dynamic",
+    "kubernetes",
     "kubernetes/scheme",
+    "kubernetes/typed/admissionregistration/v1alpha1",
+    "kubernetes/typed/admissionregistration/v1beta1",
+    "kubernetes/typed/apps/v1",
+    "kubernetes/typed/apps/v1beta1",
+    "kubernetes/typed/apps/v1beta2",
+    "kubernetes/typed/authentication/v1",
+    "kubernetes/typed/authentication/v1beta1",
+    "kubernetes/typed/authorization/v1",
+    "kubernetes/typed/authorization/v1beta1",
+    "kubernetes/typed/autoscaling/v1",
+    "kubernetes/typed/autoscaling/v2beta1",
+    "kubernetes/typed/batch/v1",
+    "kubernetes/typed/batch/v1beta1",
+    "kubernetes/typed/batch/v2alpha1",
+    "kubernetes/typed/certificates/v1beta1",
+    "kubernetes/typed/core/v1",
+    "kubernetes/typed/events/v1beta1",
+    "kubernetes/typed/extensions/v1beta1",
+    "kubernetes/typed/networking/v1",
+    "kubernetes/typed/policy/v1beta1",
+    "kubernetes/typed/rbac/v1",
+    "kubernetes/typed/rbac/v1alpha1",
+    "kubernetes/typed/rbac/v1beta1",
+    "kubernetes/typed/scheduling/v1alpha1",
+    "kubernetes/typed/scheduling/v1beta1",
+    "kubernetes/typed/settings/v1alpha1",
+    "kubernetes/typed/storage/v1",
+    "kubernetes/typed/storage/v1alpha1",
+    "kubernetes/typed/storage/v1beta1",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
     "pkg/apis/clientauthentication/v1beta1",
@@ -485,6 +528,7 @@
     "tools/clientcmd/api/v1",
     "tools/metrics",
     "tools/pager",
+    "tools/reference",
     "transport",
     "util/buffer",
     "util/cert",
@@ -542,6 +586,14 @@
   revision = "4242d8e6c5dba56827bb7bcf14ad11cda38f3991"
 
 [[projects]]
+  digest = "1:e2999bf1bb6eddc2a6aa03fe5e6629120a53088926520ca3b4765f77d7ff7eab"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
+  version = "v0.1.0"
+
+[[projects]]
   digest = "1:29062cae7f41050794c47913d342e73180c64dbc6628db930726fee5dac10474"
   name = "k8s.io/kubernetes"
   packages = ["pkg/util/pointer"]
@@ -559,6 +611,9 @@
     "github.com/google/go-jsonnet/ast",
     "go.opencensus.io/exporter/prometheus",
     "go.opencensus.io/stats/view",
+    "k8s.io/api/core/v1",
+    "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",
+    "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
     "k8s.io/apimachinery/pkg/api/equality",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/testing/fuzzer",
@@ -579,6 +634,7 @@
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/dynamic",
+    "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/plugin/pkg/client/auth/oidc",
     "k8s.io/client-go/rest",
     "k8s.io/client-go/tools/cache",
@@ -590,6 +646,7 @@
     "k8s.io/code-generator/cmd/deepcopy-gen",
     "k8s.io/code-generator/cmd/informer-gen",
     "k8s.io/code-generator/cmd/lister-gen",
+    "k8s.io/klog",
     "k8s.io/kubernetes/pkg/util/pointer",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,6 +37,10 @@ required = [
   version = "kubernetes-1.11.0"
 
 [[constraint]]
+  name = "k8s.io/apiextensions-apiserver"
+  version = "kubernetes-1.11.0"
+
+[[constraint]]
   name = "k8s.io/code-generator"
   version = "kubernetes-1.11.0"
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ unit-test:
 	go test -i ./...
 	go test ./...
 
+integration-test:
+	go test -i ./test/integration/...
+	go test ./test/integration/... -args -v=6
+
 image: generated_files
 	docker build -t metacontroller/metacontroller:$(TAG) .
 

--- a/Makefile
+++ b/Makefile
@@ -9,12 +9,13 @@ install: generated_files
 	go install
 
 unit-test:
-	go test -i ./...
-	go test ./...
+	pkgs="$$(go list ./... | grep -v /test/integration/)" ; \
+		go test -i $${pkgs} && \
+		go test $${pkgs}
 
 integration-test:
 	go test -i ./test/integration/...
-	go test ./test/integration/... -args -v=6
+	PATH="$(PWD)/hack/bin:$(PATH)" go test ./test/integration/... -v -timeout 5m -args -v=6
 
 image: generated_files
 	docker build -t metacontroller/metacontroller:$(TAG) .

--- a/controller/composite/controller_revision.go
+++ b/controller/composite/controller_revision.go
@@ -80,7 +80,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 	// children anyway.
 	if !pc.updateStrategy.anyRolling() ||
 		(parent.GetDeletionTimestamp() != nil && !pc.finalizer.ShouldFinalize(parent)) {
-		syncRequest := &syncHookRequest{
+		syncRequest := &SyncHookRequest{
 			Controller: pc.cc,
 			Parent:     parent,
 			Children:   observedChildren,
@@ -150,7 +150,7 @@ func (pc *parentController) syncRevisions(parent *unstructured.Unstructured, obs
 		go func(pr *parentRevision) {
 			defer wg.Done()
 
-			syncRequest := &syncHookRequest{
+			syncRequest := &SyncHookRequest{
 				Controller: pc.cc,
 				Parent:     pr.parent,
 				Children:   observedChildren,

--- a/controller/composite/hooks.go
+++ b/controller/composite/hooks.go
@@ -20,21 +20,22 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"metacontroller.app/apis/metacontroller/v1alpha1"
 	"metacontroller.app/controller/common"
 	"metacontroller.app/hooks"
 )
 
-type syncHookRequest struct {
-	Controller runtime.Object             `json:"controller"`
-	Parent     *unstructured.Unstructured `json:"parent"`
-	Children   common.ChildMap            `json:"children"`
-	Finalizing bool                       `json:"finalizing"`
+// SyncHookRequest is the object sent as JSON to the sync hook.
+type SyncHookRequest struct {
+	Controller *v1alpha1.CompositeController `json:"controller"`
+	Parent     *unstructured.Unstructured    `json:"parent"`
+	Children   common.ChildMap               `json:"children"`
+	Finalizing bool                          `json:"finalizing"`
 }
 
-type syncHookResponse struct {
+// SyncHookResponse is the expected format of the JSON response from the sync hook.
+type SyncHookResponse struct {
 	Status   map[string]interface{}       `json:"status"`
 	Children []*unstructured.Unstructured `json:"children"`
 
@@ -42,12 +43,12 @@ type syncHookResponse struct {
 	Finalized bool `json:"finalized"`
 }
 
-func callSyncHook(cc *v1alpha1.CompositeController, request *syncHookRequest) (*syncHookResponse, error) {
+func callSyncHook(cc *v1alpha1.CompositeController, request *SyncHookRequest) (*SyncHookResponse, error) {
 	if cc.Spec.Hooks == nil {
 		return nil, fmt.Errorf("no hooks defined")
 	}
 
-	var response syncHookResponse
+	var response SyncHookResponse
 
 	// First check if we should instead call the finalize hook,
 	// which has the same API as the sync hook except that it's

--- a/controller/decorator/controller.go
+++ b/controller/decorator/controller.go
@@ -451,7 +451,7 @@ func (c *decoratorController) syncParentObject(parent *unstructured.Unstructured
 	var desiredChildren common.ChildMap
 
 	// Call the sync hook to get the desired annotations and children.
-	syncRequest := &syncHookRequest{
+	syncRequest := &SyncHookRequest{
 		Controller:  c.dc,
 		Object:      parent,
 		Attachments: observedChildren,

--- a/controller/decorator/hooks.go
+++ b/controller/decorator/hooks.go
@@ -20,20 +20,22 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 
+	"metacontroller.app/apis/metacontroller/v1alpha1"
 	"metacontroller.app/controller/common"
 	"metacontroller.app/hooks"
 )
 
-type syncHookRequest struct {
-	Controller  runtime.Object             `json:"controller"`
-	Object      *unstructured.Unstructured `json:"object"`
-	Attachments common.ChildMap            `json:"attachments"`
-	Finalizing  bool                       `json:"finalizing"`
+// SyncHookRequest is the object sent as JSON to the sync hook.
+type SyncHookRequest struct {
+	Controller  *v1alpha1.DecoratorController `json:"controller"`
+	Object      *unstructured.Unstructured    `json:"object"`
+	Attachments common.ChildMap               `json:"attachments"`
+	Finalizing  bool                          `json:"finalizing"`
 }
 
-type syncHookResponse struct {
+// SyncHookResponse is the expected format of the JSON response from the sync hook.
+type SyncHookResponse struct {
 	Labels      map[string]*string           `json:"labels"`
 	Annotations map[string]*string           `json:"annotations"`
 	Status      map[string]interface{}       `json:"status"`
@@ -43,12 +45,12 @@ type syncHookResponse struct {
 	Finalized bool `json:"finalized"`
 }
 
-func (c *decoratorController) callSyncHook(request *syncHookRequest) (*syncHookResponse, error) {
+func (c *decoratorController) callSyncHook(request *SyncHookRequest) (*SyncHookResponse, error) {
 	if c.dc.Spec.Hooks == nil {
 		return nil, fmt.Errorf("no hooks defined")
 	}
 
-	var response syncHookResponse
+	var response SyncHookResponse
 
 	// First check if we should instead call the finalize hook,
 	// which has the same API as the sync hook except that it's

--- a/docs/_contrib/build.md
+++ b/docs/_contrib/build.md
@@ -1,6 +1,6 @@
 ---
 title: Building
-toc: false
+toc: true
 classes: wide
 ---
 The page describes how to build Metacontroller for yourself.
@@ -72,3 +72,93 @@ you may need to update generated files before building:
 go get -u k8s.io/code-generator/cmd/{lister,client,informer,deepcopy}-gen
 make generated_files
 ```
+
+## Tests
+
+To run tests, first make sure you can successfully complete a [local build](#local-build).
+
+### Unit Tests
+
+Unit tests in Metacontroller focus on code that does some kind of non-trival
+local computation without depending on calls to remote servers -- for example,
+the `./dynamic/apply` package.
+
+Unit tests live in `_test.go` files alongside the code that they test.
+To run only unit tests (excluding [integration tests](#integration-tests))
+for all Metacontroller packages, use this command:
+
+```sh
+make unit-test
+```
+
+### Integration Tests
+
+Integration tests in Metacontroller focus on verifying behavior at the level of
+calls to remote services like user-provided webhooks and the Kubernetes API server.
+Since Metacontroller's job is ultimately to manipulate Kubernetes API objects in
+response to other Kubernetes API objects, most of the important features or
+behaviors of Metacontroller can and should be tested at this level.
+
+In the integration test environment, we start a standalone `kube-apiserver` to
+serve the REST APIs, and an `etcd` instance to back it.
+We do *not* run any kubelets (Nodes), nor any controllers other than
+Metacontroller.
+This makes it easy for tests to control exactly what API objects Metacontroller
+sees without interference from the normal controller for each API,
+and also greatly reduces the requirements to run tests.
+
+Other than the Metacontroller codebase, all you need to run integration tests
+is to download a few binaries from a Kubernetes release.
+You can run the following script to fetch the versions of these binaries
+currently used in continuous integration, and place them in `./hack/bin`:
+
+```sh
+hack/get-kube-binaries.sh
+```
+
+You can then run the integration tests with this command, which will
+automatically set the PATH to include `./hack/bin`:
+
+```sh
+make integration-test
+```
+
+Unlike unit tests, integration tests do not live alongside the code they test,
+but instead are gathered in `./test/integration/...`.
+This makes it easier to run them separately, since they require a special
+environment, and also enforces that they test packages at the level of their
+public interfaces.
+
+### End-to-End Tests
+
+End-to-end tests in Metacontroller focus on verifying example workflows that we
+expect to be typical for end users. That is, we run the same `kubectl` commands
+that a human might run when using Metacontroller.
+
+Since these tests verify end-to-end behavior, they require a fully-functioning
+Kubernetes cluster.
+Before running them, you should have `kubectl` in your PATH, and it should be
+configured to talk to a suitable, empty test cluster.
+
+Then you can run the end-to-end tests against your cluster with the following:
+
+```sh
+cd examples
+./test.sh
+```
+
+This will run all the end-to-end tests in series, and print the location of a
+log file containing the output of the latest test that was run.
+
+You can also run each test individually, which will show the output as it runs.
+For example:
+
+```sh
+cd examples/bluegreen
+./test.sh
+```
+
+Note that currently our continuous integration only runs unit and integration
+tests on PRs, since those don't require a full cluster.
+If you have access to a suitable test cluster, you can help speed up review of
+your PR by running these end-to-end tests yourself to see if they catch anything.

--- a/hack/get-kube-binaries.sh
+++ b/hack/get-kube-binaries.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+set -u
+
+# This script downloads etcd and Kubernetes binaries that are
+# used as part of the integration test environment,
+# and places them in hack/bin/.
+#
+# The integration test framework expects these binaries to be found in the PATH.
+
+# This is the kube-apiserver version to test against.
+KUBE_VERSION="${KUBE_VERSION:-v1.11.3}"
+KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://dl.k8s.io}"
+
+# This should be the etcd version downloaded by kubernetes/hack/lib/etcd.sh
+# as of the above Kubernetes version.
+ETCD_VERSION="${ETCD_VERSION:-v3.2.18}"
+
+mkdir -p hack/bin
+cd hack/bin
+
+# Download kubectl.
+rm -f kubectl
+wget "${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/bin/linux/amd64/kubectl"
+chmod +x kubectl
+
+# Download kube-apiserver.
+rm -f kube-apiserver
+wget "${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/bin/linux/amd64/kube-apiserver"
+chmod +x kube-apiserver
+
+# Download etcd.
+rm -f etcd
+basename="etcd-${ETCD_VERSION}-linux-amd64"
+filename="${basename}.tar.gz"
+url="https://github.com/coreos/etcd/releases/download/${ETCD_VERSION}/${filename}"
+wget "${url}"
+tar -zxf "${filename}"
+mv "${basename}/etcd" etcd
+rm -rf "${basename}" "${filename}"

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/0xRLG/ocworkqueue"
+	"go.opencensus.io/stats/view"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/util/workqueue"
+
+	"metacontroller.app/apis/metacontroller/v1alpha1"
+	mcclientset "metacontroller.app/client/generated/clientset/internalclientset"
+	mcinformers "metacontroller.app/client/generated/informer/externalversions"
+	"metacontroller.app/controller/composite"
+	"metacontroller.app/controller/decorator"
+	dynamicclientset "metacontroller.app/dynamic/clientset"
+	dynamicdiscovery "metacontroller.app/dynamic/discovery"
+	dynamicinformer "metacontroller.app/dynamic/informer"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+)
+
+type controller interface {
+	Start()
+	Stop()
+}
+
+func Start(config *rest.Config, discoveryInterval, informerRelist time.Duration) (stop func(), err error) {
+	// Periodically refresh discovery to pick up newly-installed resources.
+	dc := discovery.NewDiscoveryClientForConfigOrDie(config)
+	resources := dynamicdiscovery.NewResourceMap(dc)
+	// We don't care about stopping this cleanly since it has no external effects.
+	resources.Start(discoveryInterval)
+
+	// Create informer factory for metacontroller API objects.
+	mcClient, err := mcclientset.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("Can't create client for api %s: %v", v1alpha1.SchemeGroupVersion, err)
+	}
+	mcInformerFactory := mcinformers.NewSharedInformerFactory(mcClient, informerRelist)
+
+	// Create dynamic clientset (factory for dynamic clients).
+	dynClient, err := dynamicclientset.New(config, resources)
+	if err != nil {
+		return nil, err
+	}
+	// Create dynamic informer factory (for sharing dynamic informers).
+	dynInformers := dynamicinformer.NewSharedInformerFactory(dynClient, informerRelist)
+
+	workqueue.SetProvider(ocworkqueue.MetricsProvider())
+	view.Register(ocworkqueue.DefaultViews...)
+
+	// Start metacontrollers (controllers that spawn controllers).
+	// Each one requests the informers it needs from the factory.
+	controllers := []controller{
+		composite.NewMetacontroller(resources, dynClient, dynInformers, mcInformerFactory, mcClient),
+		decorator.NewMetacontroller(resources, dynClient, dynInformers, mcInformerFactory),
+	}
+
+	// Start all requested informers.
+	// We don't care about stopping this cleanly since it has no external effects.
+	mcInformerFactory.Start(nil)
+
+	// Start all controllers.
+	for _, c := range controllers {
+		c.Start()
+	}
+
+	// Return a function that will stop all controllers.
+	return func() {
+		var wg sync.WaitGroup
+		for _, c := range controllers {
+			wg.Add(1)
+			go func(c controller) {
+				defer wg.Done()
+				c.Stop()
+			}(c)
+		}
+		wg.Wait()
+	}, nil
+}

--- a/test/integration/composite/composite_test.go
+++ b/test/integration/composite/composite_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package composite
+
+import (
+	"testing"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
+
+	"metacontroller.app/controller/composite"
+	"metacontroller.app/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.TestMain(m.Run)
+}
+
+// TestSyncWebhook tests that the sync webhook triggers and passes the
+// resquest/response properly.
+func TestSyncWebhook(t *testing.T) {
+	ns := "test-sync-webhook"
+	labels := map[string]string{
+		"test": "test",
+	}
+
+	f := framework.NewFixture(t)
+	defer f.TearDown()
+
+	f.CreateNamespace(ns)
+	parentCRD, parentClient := f.CreateCRD("Parent", apiextensions.NamespaceScoped)
+	childCRD, childClient := f.CreateCRD("Child", apiextensions.NamespaceScoped)
+
+	hook := f.ServeWebhook(func(body []byte) ([]byte, error) {
+		req := composite.SyncHookRequest{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			return nil, err
+		}
+		// As a simple test of request/response content,
+		// just create a child with the same name as the parent.
+		child := framework.UnstructuredCRD(childCRD, req.Parent.GetName())
+		child.SetLabels(labels)
+		resp := composite.SyncHookResponse{
+			Children: []*unstructured.Unstructured{child},
+		}
+		return json.Marshal(resp)
+	})
+
+	f.CreateCompositeController("cc", hook.URL, parentCRD, childCRD)
+
+	parent := framework.UnstructuredCRD(parentCRD, "test-sync-webhook")
+	unstructured.SetNestedStringMap(parent.Object, labels, "spec", "selector", "matchLabels")
+	_, err := parentClient.Namespace(ns).Create(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Waiting for child object to be created...")
+	err = f.Wait(func() (bool, error) {
+		_, err = childClient.Namespace(ns).Get("test-sync-webhook", metav1.GetOptions{})
+		return err == nil, err
+	})
+	if err != nil {
+		t.Errorf("didn't find expected child: %v", err)
+	}
+}

--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+/*
+This file replaces the mechanism for starting kube-apiserver used in
+k8s.io/kubernetes integration tests. In k8s.io/kubernetes, the apiserver is
+one of the components being tested, so it makes sense that there we build it
+from scratch and link it into the test binary. However, here we treat the
+apiserver as an external component just like etcd. This avoids having to vendor
+and build all of Kubernetes into our test binary.
+*/
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strconv"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/klog"
+)
+
+var apiserverURL = ""
+
+const installApiserver = `
+Cannot find kube-apiserver, cannot run integration tests
+
+Please download kube-apiserver and ensure it is somewhere in the PATH.
+See hack/get-kube-binaries.sh
+
+`
+
+// getApiserverPath returns a path to a kube-apiserver executable.
+func getApiserverPath() (string, error) {
+	return exec.LookPath("kube-apiserver")
+}
+
+// startApiserver executes a kube-apiserver instance.
+// The returned function will signal the process and wait for it to exit.
+func startApiserver() (func(), error) {
+	apiserverPath, err := getApiserverPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, installApiserver)
+		return nil, fmt.Errorf("could not find kube-apiserver in PATH: %v", err)
+	}
+	apiserverPort, err := getAvailablePort()
+	if err != nil {
+		return nil, fmt.Errorf("could not get a port: %v", err)
+	}
+	apiserverURL = fmt.Sprintf("http://127.0.0.1:%d", apiserverPort)
+	klog.Infof("starting kube-apiserver on %s", apiserverURL)
+
+	apiserverDataDir, err := ioutil.TempDir(os.TempDir(), "integration_test_apiserver_data")
+	if err != nil {
+		return nil, fmt.Errorf("unable to make temp kube-apiserver data dir: %v", err)
+	}
+	klog.Infof("storing kube-apiserver data in: %v", apiserverDataDir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(
+		ctx,
+		apiserverPath,
+		"--cert-dir", apiserverDataDir,
+		"--insecure-port", strconv.Itoa(apiserverPort),
+		"--etcd-servers", etcdURL,
+	)
+
+	// Uncomment these to see kube-apiserver output in test logs.
+	// For Metacontroller tests, we generally don't expect problems at this level.
+	//cmd.Stdout = os.Stdout
+	//cmd.Stderr = os.Stderr
+
+	stop := func() {
+		cancel()
+		err := cmd.Wait()
+		klog.Infof("kube-apiserver exit status: %v", err)
+		err = os.RemoveAll(apiserverDataDir)
+		if err != nil {
+			klog.Warningf("error during kube-apiserver cleanup: %v", err)
+		}
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to run kube-apiserver: %v", err)
+	}
+	return stop, nil
+}
+
+// ApiserverURL returns the URL of the kube-apiserver instance started by TestMain.
+func ApiserverURL() string {
+	return apiserverURL
+}
+
+// ApiserverConfig returns a rest.Config to connect to the test instance.
+func ApiserverConfig() *rest.Config {
+	return &rest.Config{
+		Host: ApiserverURL(),
+	}
+}

--- a/test/integration/framework/crd.go
+++ b/test/integration/framework/crd.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	dynamicclientset "metacontroller.app/dynamic/clientset"
+)
+
+const (
+	// APIGroup is the group used for CRDs created as part of the test.
+	APIGroup = "test.metacontroller.app"
+	// APIVersion is the group-version used for CRDs created as part of the test.
+	APIVersion = APIGroup + "/v1"
+)
+
+// CreateCRD generates a quick-and-dirty CRD for use in tests,
+// and installs it in the test environment's API server.
+func (f *Fixture) CreateCRD(kind string, scope v1beta1.ResourceScope) (*v1beta1.CustomResourceDefinition, *dynamicclientset.ResourceClient) {
+	singular := strings.ToLower(kind)
+	plural := singular + "s"
+	crd := &v1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fmt.Sprintf("%s.%s", plural, APIGroup),
+		},
+		Spec: v1beta1.CustomResourceDefinitionSpec{
+			Group: APIGroup,
+			Scope: scope,
+			Names: v1beta1.CustomResourceDefinitionNames{
+				Singular: singular,
+				Plural:   plural,
+				Kind:     kind,
+			},
+			Versions: []v1beta1.CustomResourceDefinitionVersion{
+				{
+					Name:    "v1",
+					Served:  true,
+					Storage: true,
+				},
+			},
+		},
+	}
+	crd, err := f.apiextensions.CustomResourceDefinitions().Create(crd)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.deferTeardown(func() error {
+		return f.apiextensions.CustomResourceDefinitions().Delete(crd.Name, nil)
+	})
+
+	f.t.Logf("Waiting for %v CRD to appear in API server discovery info...", kind)
+	err = f.Wait(func() (bool, error) {
+		return resourceMap.Get(APIVersion, plural) != nil, nil
+	})
+	if err != nil {
+		f.t.Fatal(err)
+	}
+
+	client, err := f.dynamic.Resource(APIVersion, plural)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+
+	f.t.Logf("Waiting for %v CRD client List() to succeed...", kind)
+	err = f.Wait(func() (bool, error) {
+		_, err := client.List(metav1.ListOptions{})
+		return err == nil, err
+	})
+	if err != nil {
+		f.t.Fatal(err)
+	}
+
+	return crd, client
+}
+
+// UnstructuredCRD creates a new Unstructured object for the given CRD.
+func UnstructuredCRD(crd *v1beta1.CustomResourceDefinition, name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetAPIVersion(crd.Spec.Group + "/" + crd.Spec.Versions[0].Name)
+	obj.SetKind(crd.Spec.Names.Kind)
+	obj.SetName(name)
+	return obj
+}

--- a/test/integration/framework/etcd.go
+++ b/test/integration/framework/etcd.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is copied from k8s.io/kubernetes/test/integration/framework/
+// to avoid vendoring the rest of the package, which depends on all of k8s.
+
+package framework
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"k8s.io/klog"
+)
+
+var etcdURL = ""
+
+const installEtcd = `
+Cannot find etcd, cannot run integration tests
+
+Please download kube-apiserver and ensure it is somewhere in the PATH.
+See hack/get-kube-binaries.sh
+
+`
+
+// getEtcdPath returns a path to an etcd executable.
+func getEtcdPath() (string, error) {
+	bazelPath := filepath.Join(os.Getenv("RUNFILES_DIR"), "com_coreos_etcd/etcd")
+	p, err := exec.LookPath(bazelPath)
+	if err == nil {
+		return p, nil
+	}
+	return exec.LookPath("etcd")
+}
+
+// getAvailablePort returns a TCP port that is available for binding.
+func getAvailablePort() (int, error) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, fmt.Errorf("could not bind to a port: %v", err)
+	}
+	// It is possible but unlikely that someone else will bind this port before we
+	// get a chance to use it.
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// startEtcd executes an etcd instance. The returned function will signal the
+// etcd process and wait for it to exit.
+func startEtcd() (func(), error) {
+	etcdPath, err := getEtcdPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, installEtcd)
+		return nil, fmt.Errorf("could not find etcd in PATH: %v", err)
+	}
+	etcdPort, err := getAvailablePort()
+	if err != nil {
+		return nil, fmt.Errorf("could not get a port: %v", err)
+	}
+	etcdURL = fmt.Sprintf("http://127.0.0.1:%d", etcdPort)
+	klog.Infof("starting etcd on %s", etcdURL)
+
+	etcdDataDir, err := ioutil.TempDir(os.TempDir(), "integration_test_etcd_data")
+	if err != nil {
+		return nil, fmt.Errorf("unable to make temp etcd data dir: %v", err)
+	}
+	klog.Infof("storing etcd data in: %v", etcdDataDir)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(
+		ctx,
+		etcdPath,
+		"--data-dir", etcdDataDir,
+		"--listen-client-urls", etcdURL,
+		"--advertise-client-urls", etcdURL,
+		"--listen-peer-urls", "http://127.0.0.1:0",
+	)
+
+	// Uncomment these to see etcd output in test logs.
+	// For Metacontroller tests, we generally don't expect problems at this level.
+	//cmd.Stdout = os.Stdout
+	//cmd.Stderr = os.Stderr
+
+	stop := func() {
+		cancel()
+		err := cmd.Wait()
+		klog.Infof("etcd exit status: %v", err)
+		err = os.RemoveAll(etcdDataDir)
+		if err != nil {
+			klog.Warningf("error during etcd cleanup: %v", err)
+		}
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("failed to run etcd: %v", err)
+	}
+	return stop, nil
+}

--- a/test/integration/framework/fixture.go
+++ b/test/integration/framework/fixture.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	mcclientset "metacontroller.app/client/generated/clientset/internalclientset"
+	dynamicclientset "metacontroller.app/dynamic/clientset"
+)
+
+const (
+	defaultWaitTimeout  = 10 * time.Second
+	defaultWaitInterval = 250 * time.Millisecond
+)
+
+// Fixture is a collection of scaffolding for each integration test method.
+type Fixture struct {
+	t *testing.T
+
+	teardownFuncs []func() error
+
+	dynamic        *dynamicclientset.Clientset
+	kubernetes     kubernetes.Interface
+	apiextensions  apiextensionsclient.ApiextensionsV1beta1Interface
+	metacontroller mcclientset.Interface
+}
+
+func NewFixture(t *testing.T) *Fixture {
+	config := ApiserverConfig()
+	apiextensions, err := apiextensionsclient.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dynClient, err := dynamicclientset.New(config, resourceMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mcClient, err := mcclientset.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return &Fixture{
+		t:              t,
+		dynamic:        dynClient,
+		kubernetes:     clientset,
+		apiextensions:  apiextensions,
+		metacontroller: mcClient,
+	}
+}
+
+// CreateNamespace creates a namespace that will be deleted after this test
+// finishes.
+func (f *Fixture) CreateNamespace(namespace string) *v1.Namespace {
+	ns := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+	ns, err := f.kubernetes.CoreV1().Namespaces().Create(ns)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.deferTeardown(func() error {
+		return f.kubernetes.CoreV1().Namespaces().Delete(ns.Name, nil)
+	})
+	return ns
+}
+
+// TearDown cleans up resources created through this instance of the test fixture.
+func (f *Fixture) TearDown() {
+	for i := len(f.teardownFuncs) - 1; i >= 0; i-- {
+		teardown := f.teardownFuncs[i]
+		if err := teardown(); err != nil {
+			f.t.Logf("Error during teardown: %v", err)
+			// Mark the test as failed, but continue trying to tear down.
+			f.t.Fail()
+		}
+	}
+}
+
+// Wait polls the condition until it's true, with a default interval and timeout.
+// This is meant for use in integration tests, so frequent polling is fine.
+//
+// The condition function returns a bool indicating whether it is satisfied,
+// as well as an error which should be non-nil if and only if the function was
+// unable to determine whether or not the condition is satisfied (for example
+// if the check involves calling a remote server and the request failed).
+//
+// If the condition function returns a non-nil error, Wait will log the error
+// and continue retrying until the timeout.
+func (f *Fixture) Wait(condition func() (bool, error)) error {
+	start := time.Now()
+	for {
+		ok, err := condition()
+		if err == nil && ok {
+			return nil
+		}
+		if err != nil {
+			// Log error, but keep trying until timeout.
+			f.t.Logf("error while waiting for condition: %v", err)
+		}
+		if time.Since(start) > defaultWaitTimeout {
+			return fmt.Errorf("timed out waiting for condition (%v)", err)
+		}
+		time.Sleep(defaultWaitInterval)
+	}
+}
+
+func (f *Fixture) deferTeardown(teardown func() error) {
+	f.teardownFuncs = append(f.teardownFuncs, teardown)
+}

--- a/test/integration/framework/main.go
+++ b/test/integration/framework/main.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+
+	"k8s.io/client-go/discovery"
+	"k8s.io/klog"
+
+	dynamicdiscovery "metacontroller.app/dynamic/discovery"
+	"metacontroller.app/server"
+)
+
+var resourceMap *dynamicdiscovery.ResourceMap
+
+const installKubectl = `
+Cannot find kubectl, cannot run integration tests
+
+Please download kubectl and ensure it is somewhere in the PATH.
+See hack/get-kube-binaries.sh
+
+`
+
+// manifestDir is the path from the integration test binary working dir to the
+// directory containing manifests to install Metacontroller.
+const manifestDir = "../../../manifests"
+
+// getKubectlPath returns a path to a kube-apiserver executable.
+func getKubectlPath() (string, error) {
+	return exec.LookPath("kubectl")
+}
+
+// TestMain starts etcd, kube-apiserver, and metacontroller before running tests.
+func TestMain(tests func() int) {
+	result := 1
+	defer func() {
+		os.Exit(result)
+	}()
+
+	if _, err := getKubectlPath(); err != nil {
+		klog.Fatal(installKubectl)
+	}
+
+	stopEtcd, err := startEtcd()
+	if err != nil {
+		klog.Fatalf("cannot run integration tests: unable to start etcd: %v", err)
+	}
+	defer stopEtcd()
+
+	stopApiserver, err := startApiserver()
+	if err != nil {
+		klog.Fatalf("cannot run integration tests: unable to start kube-apiserver: %v", err)
+	}
+	defer stopApiserver()
+
+	klog.Info("Waiting for kube-apiserver to be ready...")
+	start := time.Now()
+	for {
+		if err := execKubectl("version"); err == nil {
+			break
+		}
+		if time.Since(start) > defaultWaitTimeout {
+			klog.Fatalf("timed out waiting for kube-apiserver to be ready: %v", err)
+		}
+		time.Sleep(time.Second)
+	}
+
+	// Install Metacontroller RBAC.
+	if err := execKubectl("apply", "-f", path.Join(manifestDir, "metacontroller-rbac.yaml")); err != nil {
+		klog.Fatalf("can't install metacontroller RBAC: %v", err)
+	}
+
+	// Install Metacontroller CRDs.
+	if err := execKubectl("apply", "-f", path.Join(manifestDir, "metacontroller.yaml")); err != nil {
+		klog.Fatalf("can't install metacontroller CRDs: %v", err)
+	}
+
+	// In this integration test environment, there are no Nodes, so the
+	// metacontroller StatefulSet will not actually run anything.
+	// Instead, we start the Metacontroller server locally inside the test binary,
+	// since that's part of the code under test.
+	stopServer, err := server.Start(ApiserverConfig(), 500*time.Millisecond, 30*time.Minute)
+	if err != nil {
+		klog.Fatalf("can't start metacontroller server: %v", err)
+	}
+	defer stopServer()
+
+	// Periodically refresh discovery to pick up newly-installed resources.
+	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(ApiserverConfig())
+	resourceMap = dynamicdiscovery.NewResourceMap(discoveryClient)
+	// We don't care about stopping this cleanly since it has no external effects.
+	resourceMap.Start(500 * time.Millisecond)
+
+	result = tests()
+}
+
+func execKubectl(args ...string) error {
+	execPath, err := exec.LookPath("kubectl")
+	if err != nil {
+		return fmt.Errorf("can't exec kubectl: %v", err)
+	}
+	cmdline := append([]string{"--server", ApiserverURL()}, args...)
+	cmd := exec.Command(execPath, cmdline...)
+	return cmd.Run()
+}

--- a/test/integration/framework/metacontroller.go
+++ b/test/integration/framework/metacontroller.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
+	"metacontroller.app/apis/metacontroller/v1alpha1"
+)
+
+// CreateCompositeController generates a test CompositeController and installs
+// it in the test API server.
+func (f *Fixture) CreateCompositeController(name, syncHookURL string, parentCRD, childCRD *apiextensions.CustomResourceDefinition) *v1alpha1.CompositeController {
+	cc := &v1alpha1.CompositeController{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cc",
+		},
+		Spec: v1alpha1.CompositeControllerSpec{
+			ParentResource: v1alpha1.CompositeControllerParentResourceRule{
+				ResourceRule: v1alpha1.ResourceRule{
+					APIVersion: parentCRD.Spec.Group + "/" + parentCRD.Spec.Versions[0].Name,
+					Resource:   parentCRD.Spec.Names.Plural,
+				},
+			},
+			ChildResources: []v1alpha1.CompositeControllerChildResourceRule{
+				{
+					ResourceRule: v1alpha1.ResourceRule{
+						APIVersion: childCRD.Spec.Group + "/" + childCRD.Spec.Versions[0].Name,
+						Resource:   childCRD.Spec.Names.Plural,
+					},
+				},
+			},
+			Hooks: &v1alpha1.CompositeControllerHooks{
+				Sync: &v1alpha1.Hook{
+					Webhook: &v1alpha1.Webhook{
+						URL: &syncHookURL,
+					},
+				},
+			},
+		},
+	}
+
+	cc, err := f.metacontroller.MetacontrollerV1alpha1().CompositeControllers().Create(cc)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	f.deferTeardown(func() error {
+		return f.metacontroller.MetacontrollerV1alpha1().CompositeControllers().Delete(cc.Name, nil)
+	})
+
+	return cc
+}

--- a/test/integration/framework/webhook.go
+++ b/test/integration/framework/webhook.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+)
+
+// ServeWebhook is a helper for quickly creating a webhook server in tests.
+func (f *Fixture) ServeWebhook(handler func(request []byte) (response []byte, err error)) *httptest.Server {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "unsupported method", http.StatusMethodNotAllowed)
+			return
+		}
+
+		body, err := ioutil.ReadAll(r.Body)
+		r.Body.Close()
+		if err != nil {
+			http.Error(w, "can't read body", http.StatusBadRequest)
+			return
+		}
+
+		resp, err := handler(body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(resp)
+	}))
+	f.deferTeardown(func() error {
+		srv.Close()
+		return nil
+	})
+	return srv
+}


### PR DESCRIPTION
This adds a framework for integration tests that run against a bare kube-apiserver with no other Kubernetes components (i.e. no kubelets). Unlike the end-to-end tests in `examples/`, these integration tests don't require an actual Kubernetes cluster. This allows efficient testing of Metacontroller behavior at the level of its interaction with Kubernetes API objects, after which the respective implementations of those APIs are assumed to work.

This also includes the first sample test, which exercises a simple CompositeController sync webhook scenario to validate the test framework. Additional tests will be added in separate PRs.