### PR TITLE
Change app label

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,5 +1,6 @@
 commonLabels:
-  app: metacontroller
+  app.kubernetes.io/name: metacontroller
+
 resources:
 - manifests/metacontroller-rbac.yaml
 - manifests/metacontroller.yaml


### PR DESCRIPTION
This changes the `app` label to `app.kubernetes.io/name` as [recommended](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels) by SIG-Apps.

I'll likely quiet down after this 😄 