### PR TITLE
Add basic integration test for DecoratorController.

### DIFF
--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -78,6 +78,8 @@ func startApiserver() (func(), error) {
 		ctx,
 		apiserverPath,
 		"--cert-dir", apiserverDataDir,
+		// Disable secure port since we don't use it, so we don't conflict with other apiservers.
+		"--secure-port", "0",
 		"--insecure-port", strconv.Itoa(apiserverPort),
 		"--etcd-servers", etcdURL,
 	)

--- a/test/integration/framework/fixture.go
+++ b/test/integration/framework/fixture.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	defaultWaitTimeout  = 10 * time.Second
+	defaultWaitTimeout  = 60 * time.Second
 	defaultWaitInterval = 250 * time.Millisecond
 )
 


### PR DESCRIPTION
This is a skeleton for DecoratorController integration tests, just like the one for CompositeController. This also fixes the test framework so integration tests can run in parallel.