### PR TITLE
Always delete children with cascading deletion.

### DIFF
--- a/controller/common/manage_children.go
+++ b/controller/common/manage_children.go
@@ -170,8 +170,12 @@ func deleteChildren(client *dynamicclientset.ResourceClient, parent *unstructure
 			// This observed object wasn't listed as desired.
 			glog.Infof("%v: deleting %v", describeObject(parent), describeObject(obj))
 			uid := obj.GetUID()
+			// Explicitly request deletion propagation, which is what users expect,
+			// since some objects default to orphaning for backwards compatibility.
+			propagation := metav1.DeletePropagationBackground
 			err := client.Namespace(obj.GetNamespace()).Delete(obj.GetName(), &metav1.DeleteOptions{
-				Preconditions: &metav1.Preconditions{UID: &uid},
+				Preconditions:     &metav1.Preconditions{UID: &uid},
+				PropagationPolicy: &propagation,
 			})
 			if err != nil {
 				errs = append(errs, fmt.Errorf("can't delete %v: %v", describeObject(obj), err))
@@ -223,8 +227,12 @@ func updateChildren(client *dynamicclientset.ResourceClient, updateStrategy Chil
 				// Delete the object (now) and recreate it (on the next sync).
 				glog.Infof("%v: deleting %v for update", describeObject(parent), describeObject(obj))
 				uid := oldObj.GetUID()
+				// Explicitly request deletion propagation, which is what users expect,
+				// since some objects default to orphaning for backwards compatibility.
+				propagation := metav1.DeletePropagationBackground
 				err := client.Namespace(ns).Delete(obj.GetName(), &metav1.DeleteOptions{
-					Preconditions: &metav1.Preconditions{UID: &uid},
+					Preconditions:     &metav1.Preconditions{UID: &uid},
+					PropagationPolicy: &propagation,
 				})
 				if err != nil {
 					errs = append(errs, err)

--- a/test/integration/composite/composite_test.go
+++ b/test/integration/composite/composite_test.go
@@ -19,11 +19,14 @@ package composite
 import (
 	"testing"
 
+	batchv1 "k8s.io/api/batch/v1"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/json"
 
+	"metacontroller.app/apis/metacontroller/v1alpha1"
 	"metacontroller.app/controller/composite"
 	"metacontroller.app/test/integration/framework"
 )
@@ -37,15 +40,15 @@ func TestMain(m *testing.M) {
 func TestSyncWebhook(t *testing.T) {
 	ns := "test-sync-webhook"
 	labels := map[string]string{
-		"test": "test",
+		"test": "test-sync-webhook",
 	}
 
 	f := framework.NewFixture(t)
 	defer f.TearDown()
 
 	f.CreateNamespace(ns)
-	parentCRD, parentClient := f.CreateCRD("Parent", apiextensions.NamespaceScoped)
-	childCRD, childClient := f.CreateCRD("Child", apiextensions.NamespaceScoped)
+	parentCRD, parentClient := f.CreateCRD("TestSyncWebhookParent", apiextensions.NamespaceScoped)
+	childCRD, childClient := f.CreateCRD("TestSyncWebhookChild", apiextensions.NamespaceScoped)
 
 	hook := f.ServeWebhook(func(body []byte) ([]byte, error) {
 		req := composite.SyncHookRequest{}
@@ -62,7 +65,7 @@ func TestSyncWebhook(t *testing.T) {
 		return json.Marshal(resp)
 	})
 
-	f.CreateCompositeController("cc", hook.URL, parentCRD, childCRD)
+	f.CreateCompositeController("test-sync-webhook", hook.URL, framework.CRDResourceRule(parentCRD), framework.CRDResourceRule(childCRD))
 
 	parent := framework.UnstructuredCRD(parentCRD, "test-sync-webhook")
 	unstructured.SetNestedStringMap(parent.Object, labels, "spec", "selector", "matchLabels")
@@ -73,10 +76,104 @@ func TestSyncWebhook(t *testing.T) {
 
 	t.Logf("Waiting for child object to be created...")
 	err = f.Wait(func() (bool, error) {
-		_, err = childClient.Namespace(ns).Get("test-sync-webhook", metav1.GetOptions{})
+		_, err := childClient.Namespace(ns).Get("test-sync-webhook", metav1.GetOptions{})
 		return err == nil, err
 	})
 	if err != nil {
 		t.Errorf("didn't find expected child: %v", err)
+	}
+}
+
+// TestCascadingDelete tests that we request cascading deletion of children,
+// even if the server-side default for that child type is non-cascading.
+func TestCacadingDelete(t *testing.T) {
+	ns := "test-cascading-delete"
+	labels := map[string]string{
+		"test": "test-cascading-delete",
+	}
+
+	f := framework.NewFixture(t)
+	defer f.TearDown()
+
+	f.CreateNamespace(ns)
+	parentCRD, parentClient := f.CreateCRD("TestCascadingDeleteParent", apiextensions.NamespaceScoped)
+	childClient := f.Clientset().BatchV1().Jobs(ns)
+
+	hook := f.ServeWebhook(func(body []byte) ([]byte, error) {
+		req := composite.SyncHookRequest{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			return nil, err
+		}
+		resp := composite.SyncHookResponse{}
+		if replicas, _, _ := unstructured.NestedInt64(req.Parent.Object, "spec", "replicas"); replicas > 0 {
+			// Create a child batch/v1 Job if requested.
+			// For backward compatibility, the server-side default on that API is
+			// non-cascading deletion (don't delete Pods).
+			// So we can use this as a test case for whether we are correctly requesting
+			// cascading deletion.
+			child := framework.UnstructuredJSON("batch/v1", "Job", "test-cascading-delete", `{
+				"spec": {
+					"template": {
+						"spec": {
+							"restartPolicy": "Never",
+							"containers": [
+								{
+									"name": "pi",
+									"image": "perl"
+								}
+							]
+						}
+					}
+				}
+			}`)
+			child.SetLabels(labels)
+			resp.Children = append(resp.Children, child)
+		}
+		return json.Marshal(resp)
+	})
+
+	f.CreateCompositeController("test-cascading-delete", hook.URL, framework.CRDResourceRule(parentCRD), v1alpha1.ResourceRule{APIVersion: "batch/v1", Resource: "jobs"})
+
+	parent := framework.UnstructuredCRD(parentCRD, "test-cascading-delete")
+	unstructured.SetNestedStringMap(parent.Object, labels, "spec", "selector", "matchLabels")
+	unstructured.SetNestedField(parent.Object, int64(1), "spec", "replicas")
+	var err error
+	if parent, err = parentClient.Namespace(ns).Create(parent); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Waiting for child object to be created...")
+	err = f.Wait(func() (bool, error) {
+		_, err := childClient.Get("test-cascading-delete", metav1.GetOptions{})
+		return err == nil, err
+	})
+	if err != nil {
+		t.Errorf("didn't find expected child: %v", err)
+	}
+
+	// Now that child exists, tell parent to delete it.
+	t.Logf("Updating parent to set replicas=0...")
+	_, err = parentClient.Namespace(ns).AtomicUpdate(parent, func(obj *unstructured.Unstructured) bool {
+		unstructured.SetNestedField(obj.Object, int64(0), "spec", "replicas")
+		return true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Make sure the child gets actually deleted, which means no GC finalizers got
+	// added to it. Note that we don't actually run the GC in this integration
+	// test env, so we don't need to worry about the GC racing us to process the
+	// finalizers.
+	t.Logf("Waiting for child object to be deleted...")
+	var child *batchv1.Job
+	err = f.Wait(func() (bool, error) {
+		var getErr error
+		child, getErr = childClient.Get("test-cascading-delete", metav1.GetOptions{})
+		return apierrors.IsNotFound(getErr), nil
+	})
+	if err != nil {
+		out, _ := json.Marshal(child)
+		t.Errorf("timed out waiting for child object to be deleted: %v; object: %s", err, out)
 	}
 }

--- a/test/integration/decorator/decorator_test.go
+++ b/test/integration/decorator/decorator_test.go
@@ -62,7 +62,7 @@ func TestSyncWebhook(t *testing.T) {
 		return json.Marshal(resp)
 	})
 
-	f.CreateDecoratorController("dc", hook.URL, parentCRD, childCRD)
+	f.CreateDecoratorController("dc", hook.URL, framework.CRDResourceRule(parentCRD), framework.CRDResourceRule(childCRD))
 
 	parent := framework.UnstructuredCRD(parentCRD, "test-sync-webhook")
 	unstructured.SetNestedStringMap(parent.Object, labels, "spec", "selector", "matchLabels")

--- a/test/integration/framework/crd.go
+++ b/test/integration/framework/crd.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/json"
 
 	dynamicclientset "metacontroller.app/dynamic/clientset"
 )
@@ -100,4 +101,19 @@ func UnstructuredCRD(crd *v1beta1.CustomResourceDefinition, name string) *unstru
 	obj.SetKind(crd.Spec.Names.Kind)
 	obj.SetName(name)
 	return obj
+}
+
+// UnstructuredJSON creates a new Unstructured object from the given JSON.
+// It panics on a decode error because it's meant for use with hard-coded test
+// data.
+func UnstructuredJSON(apiVersion, kind, name, jsonStr string) *unstructured.Unstructured {
+	obj := map[string]interface{}{}
+	if err := json.Unmarshal([]byte(jsonStr), &obj); err != nil {
+		panic(err)
+	}
+	u := &unstructured.Unstructured{Object: obj}
+	u.SetAPIVersion(apiVersion)
+	u.SetKind(kind)
+	u.SetName(name)
+	return u
 }

--- a/test/integration/framework/fixture.go
+++ b/test/integration/framework/fixture.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	defaultWaitTimeout  = 60 * time.Second
+	defaultWaitTimeout  = 30 * time.Second
 	defaultWaitInterval = 250 * time.Millisecond
 )
 
@@ -73,6 +73,11 @@ func NewFixture(t *testing.T) *Fixture {
 		apiextensions:  apiextensions,
 		metacontroller: mcClient,
 	}
+}
+
+// Clientset returns the Kubernetes clientset.
+func (f *Fixture) Clientset() kubernetes.Interface {
+	return f.kubernetes
 }
 
 // CreateNamespace creates a namespace that will be deleted after this test

--- a/test/integration/framework/main.go
+++ b/test/integration/framework/main.go
@@ -82,7 +82,7 @@ func testMain(tests func() int) error {
 		if kubectlErr == nil {
 			break
 		}
-		if time.Since(start) > defaultWaitTimeout {
+		if time.Since(start) > time.Minute {
 			return fmt.Errorf("timed out waiting for kube-apiserver to be ready: %v", kubectlErr)
 		}
 		time.Sleep(time.Second)

--- a/test/integration/framework/metacontroller.go
+++ b/test/integration/framework/metacontroller.go
@@ -24,9 +24,16 @@ import (
 	"metacontroller.app/apis/metacontroller/v1alpha1"
 )
 
+func CRDResourceRule(crd *apiextensions.CustomResourceDefinition) v1alpha1.ResourceRule {
+	return v1alpha1.ResourceRule{
+		APIVersion: crd.Spec.Group + "/" + crd.Spec.Versions[0].Name,
+		Resource:   crd.Spec.Names.Plural,
+	}
+}
+
 // CreateCompositeController generates a test CompositeController and installs
 // it in the test API server.
-func (f *Fixture) CreateCompositeController(name, syncHookURL string, parentCRD, childCRD *apiextensions.CustomResourceDefinition) *v1alpha1.CompositeController {
+func (f *Fixture) CreateCompositeController(name, syncHookURL string, parentRule, childRule v1alpha1.ResourceRule) *v1alpha1.CompositeController {
 	cc := &v1alpha1.CompositeController{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -34,17 +41,11 @@ func (f *Fixture) CreateCompositeController(name, syncHookURL string, parentCRD,
 		},
 		Spec: v1alpha1.CompositeControllerSpec{
 			ParentResource: v1alpha1.CompositeControllerParentResourceRule{
-				ResourceRule: v1alpha1.ResourceRule{
-					APIVersion: parentCRD.Spec.Group + "/" + parentCRD.Spec.Versions[0].Name,
-					Resource:   parentCRD.Spec.Names.Plural,
-				},
+				ResourceRule: parentRule,
 			},
 			ChildResources: []v1alpha1.CompositeControllerChildResourceRule{
 				{
-					ResourceRule: v1alpha1.ResourceRule{
-						APIVersion: childCRD.Spec.Group + "/" + childCRD.Spec.Versions[0].Name,
-						Resource:   childCRD.Spec.Names.Plural,
-					},
+					ResourceRule: childRule,
 				},
 			},
 			Hooks: &v1alpha1.CompositeControllerHooks{
@@ -70,7 +71,7 @@ func (f *Fixture) CreateCompositeController(name, syncHookURL string, parentCRD,
 
 // CreateDecoratorController generates a test DecoratorController and installs
 // it in the test API server.
-func (f *Fixture) CreateDecoratorController(name, syncHookURL string, parentCRD, childCRD *apiextensions.CustomResourceDefinition) *v1alpha1.DecoratorController {
+func (f *Fixture) CreateDecoratorController(name, syncHookURL string, parentRule, childRule v1alpha1.ResourceRule) *v1alpha1.DecoratorController {
 	dc := &v1alpha1.DecoratorController{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -79,18 +80,12 @@ func (f *Fixture) CreateDecoratorController(name, syncHookURL string, parentCRD,
 		Spec: v1alpha1.DecoratorControllerSpec{
 			Resources: []v1alpha1.DecoratorControllerResourceRule{
 				{
-					ResourceRule: v1alpha1.ResourceRule{
-						APIVersion: parentCRD.Spec.Group + "/" + parentCRD.Spec.Versions[0].Name,
-						Resource:   parentCRD.Spec.Names.Plural,
-					},
+					ResourceRule: parentRule,
 				},
 			},
 			Attachments: []v1alpha1.DecoratorControllerAttachmentRule{
 				{
-					ResourceRule: v1alpha1.ResourceRule{
-						APIVersion: childCRD.Spec.Group + "/" + childCRD.Spec.Versions[0].Name,
-						Resource:   childCRD.Spec.Names.Plural,
-					},
+					ResourceRule: childRule,
 				},
 			},
 			Hooks: &v1alpha1.DecoratorControllerHooks{


### PR DESCRIPTION
For most API types, the server-side default (when the client doesn't specify) is cascading deletion, meaning that the GC will clean up children owned by the object being deleted. For some legacy APIs like Job that went GA before the server-side GC was added, the default is instead orphaning, to maintain backwards compatibility.

Now that server-side cascading deletion (GC) is the norm, users expect it to happen uniformly. Therefore, we should explicitly request cascading deletion whenever we delete children in Metacontroller, in case the server-side default is different for legacy reasons.

Fixes #145