### PR TITLE
Add per-object, one-time resync.

### DIFF
--- a/controller/common/common.go
+++ b/controller/common/common.go
@@ -102,6 +102,17 @@ func (m ChildMap) ReplaceChild(parent metav1.Object, child *unstructured.Unstruc
 	}
 }
 
+// List expands the ChildMap into a flat list of child objects, in random order.
+func (m ChildMap) List() []*unstructured.Unstructured {
+	var list []*unstructured.Unstructured
+	for _, group := range m {
+		for _, obj := range group {
+			list = append(list, obj)
+		}
+	}
+	return list
+}
+
 // MakeChildMap builds the map of children resources that is suitable for use
 // in the `children` field of a CompositeController SyncRequest or
 // `attachments` field of  the  DecoratorControllers SyncRequest.

--- a/controller/composite/hooks.go
+++ b/controller/composite/hooks.go
@@ -39,6 +39,8 @@ type SyncHookResponse struct {
 	Status   map[string]interface{}       `json:"status"`
 	Children []*unstructured.Unstructured `json:"children"`
 
+	ResyncAfterSeconds float64 `json:"resyncAfterSeconds"`
+
 	// Finalized is only used by the finalize hook.
 	Finalized bool `json:"finalized"`
 }

--- a/controller/composite/rolling_update.go
+++ b/controller/composite/rolling_update.go
@@ -86,7 +86,7 @@ func (pc *parentController) syncRollingUpdate(parentRevisions []*parentRevision,
 	// Look for the next child to update, if any.
 	// We go one by one, in the order in which the controller returned them
 	// in the latest sync hook result.
-	for _, child := range latest.desiredChildList {
+	for _, child := range latest.syncResult.Children {
 		apiGroup, _ := common.ParseAPIVersion(child.GetAPIVersion())
 		kind := child.GetKind()
 		name := child.GetName()
@@ -115,7 +115,7 @@ func (pc *parentController) syncRollingUpdate(parentRevisions []*parentRevision,
 					Reason:  "RolloutWaiting",
 					Message: err.Error(),
 				}
-				dynamicobject.SetCondition(latest.status, updatedCondition)
+				dynamicobject.SetCondition(latest.syncResult.Status, updatedCondition)
 				return nil
 			}
 
@@ -133,7 +133,7 @@ func (pc *parentController) syncRollingUpdate(parentRevisions []*parentRevision,
 				Reason:  "RolloutProgressing",
 				Message: fmt.Sprintf("updating %v %v", kind, name),
 			}
-			dynamicobject.SetCondition(latest.status, updatedCondition)
+			dynamicobject.SetCondition(latest.syncResult.Status, updatedCondition)
 			return nil
 		}
 	}
@@ -145,7 +145,7 @@ func (pc *parentController) syncRollingUpdate(parentRevisions []*parentRevision,
 		Reason:  "OnLatestRevision",
 		Message: fmt.Sprintf("latest ControllerRevision: %v", latest.revision.Name),
 	}
-	dynamicobject.SetCondition(latest.status, updatedCondition)
+	dynamicobject.SetCondition(latest.syncResult.Status, updatedCondition)
 	return nil
 }
 

--- a/controller/decorator/hooks.go
+++ b/controller/decorator/hooks.go
@@ -41,6 +41,8 @@ type SyncHookResponse struct {
 	Status      map[string]interface{}       `json:"status"`
 	Attachments []*unstructured.Unstructured `json:"attachments"`
 
+	ResyncAfterSeconds float64 `json:"resyncAfterSeconds"`
+
 	// Finalized is only used by the finalize hook.
 	Finalized bool `json:"finalized"`
 }

--- a/docs/_api/compositecontroller.md
+++ b/docs/_api/compositecontroller.md
@@ -376,6 +376,7 @@ The body of your response should be a JSON object with the following fields:
 | ----- | ----------- |
 | `status` | A JSON object that will completely replace the `status` field within the parent object. |
 | `children` | A list of JSON objects representing all the desired children for this parent object. |
+| `resyncAfterSeconds` | Set the delay (in seconds, as a float) before an optional, one-time, per-object resync. |
 
 What you put in `status` is up to you, but usually it's best to follow
 conventions established by controllers like Deployment.
@@ -406,6 +407,16 @@ response because they're in different forms.
 Instead, you should think of each entry in the list of `children` as being
 sent to [`kubectl apply`][kubectl apply].
 That is, you should [set only the fields that you care about](/api/apply/).
+
+You can optionally set `resyncAfterSeconds` to a value greater than 0 to request
+that the `sync` hook be called again with this particular parent object after
+some delay (specified in seconds, with decimal fractions allowed).
+Unlike the controller-wide [`resyncPeriodSeconds`](#resync-period), this is a
+one-time request (not a request to start periodic resyncs), although you can
+always return another `resyncAfterSeconds` value from subsequent `sync` calls.
+Also unlike the controller-wide setting, this request only applies to the
+particular parent object that this `sync` call sent, so you can request
+different delays (or omit the request) depending on the state of each object.
 
 Note that your webhook handler must return a response with a status code of `200`
 to be considered successful. Metacontroller will wait for a response for up to the
@@ -491,9 +502,9 @@ in the observed state.
 
 If the only thing you're still waiting for is a state change in an external
 system, and you don't need to assert any new desired state for your children,
-consider returning an error from your `finalize` hook instead of success.
-This will cause Metacontroller to requeue and retry the hook later, giving you
+returning success from the `finalize` hook may mean that Metacontroller doesn't
+call your hook again until the next [periodic resync](#resync-period).
+To reduce the delay, you can request a one-time, per-object resync by setting
+`resyncAfterSeconds` in your [hook response](#sync-hook-response), giving you
 a chance to recheck the external state without holding up a slot in the work
 queue.
-If you return success, Metacontroller won't call your hook again until the next
-[periodic resync](#resync-period).

--- a/test/integration/decorator/decorator_test.go
+++ b/test/integration/decorator/decorator_test.go
@@ -18,6 +18,7 @@ package decorator
 
 import (
 	"testing"
+	"time"
 
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,5 +79,80 @@ func TestSyncWebhook(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("didn't find expected child: %v", err)
+	}
+}
+
+// TestResyncAfter tests that the resyncAfterSeconds field works.
+func TestResyncAfter(t *testing.T) {
+	ns := "test-resync-after"
+	labels := map[string]string{
+		"test": "test-sync-after",
+	}
+
+	f := framework.NewFixture(t)
+	defer f.TearDown()
+
+	f.CreateNamespace(ns)
+	parentCRD, parentClient := f.CreateCRD("TestResyncAfterParent", apiextensions.NamespaceScoped)
+
+	var lastSync time.Time
+	done := false
+	hook := f.ServeWebhook(func(body []byte) ([]byte, error) {
+		req := decorator.SyncHookRequest{}
+		if err := json.Unmarshal(body, &req); err != nil {
+			return nil, err
+		}
+		resp := decorator.SyncHookResponse{}
+		if req.Object.Object["status"] == nil {
+			// If status hasn't been set yet, set it. This is the "zeroth" sync.
+			// Metacontroller will set our status and then the object should quiesce.
+			resp.Status = map[string]interface{}{}
+		} else if lastSync.IsZero() {
+			// This should be the final sync before quiescing. Do nothing except
+			// request a resync. Other than our resyncAfter request, there should be
+			// nothing that causes our object to get resynced.
+			lastSync = time.Now()
+			resp.ResyncAfterSeconds = 0.1
+		} else if !done {
+			done = true
+			// This is the second sync. Report how much time elapsed.
+			resp.Status = map[string]interface{}{
+				"elapsedSeconds": time.Since(lastSync).Seconds(),
+			}
+		} else {
+			// If we're done, just freeze the status.
+			resp.Status = req.Object.Object["status"].(map[string]interface{})
+		}
+		return json.Marshal(resp)
+	})
+
+	f.CreateDecoratorController("test-resync-after", hook.URL, framework.CRDResourceRule(parentCRD), nil)
+
+	parent := framework.UnstructuredCRD(parentCRD, "test-resync-after")
+	unstructured.SetNestedStringMap(parent.Object, labels, "spec", "selector", "matchLabels")
+	_, err := parentClient.Namespace(ns).Create(parent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("Waiting for elapsed time to be reported...")
+	var elapsedSeconds float64
+	err = f.Wait(func() (bool, error) {
+		parent, err := parentClient.Namespace(ns).Get("test-resync-after", metav1.GetOptions{})
+		val, found, err := unstructured.NestedFloat64(parent.Object, "status", "elapsedSeconds")
+		if err != nil || !found {
+			// The value hasn't been populated. Keep waiting.
+			return false, err
+		}
+		elapsedSeconds = val
+		return true, nil
+	})
+	if err != nil {
+		t.Fatalf("didn't find expected status field: %v", err)
+	}
+
+	t.Logf("elapsedSeconds: %v", elapsedSeconds)
+	if elapsedSeconds > 1.0 {
+		t.Errorf("requested resyncAfter did not occur in time; elapsedSeconds: %v", elapsedSeconds)
 	}
 }


### PR DESCRIPTION
This adds a `resyncAfterSeconds` field (can be a decimal) to the `sync` hook response of CompositeController and DecoratorController. This field allows the hook response to request a resync of one particular object after a specified delay, for example if the hook knows it wants to recheck some external state for just that object. As a result, the controller-wide resyncPeriodSeconds can be kept at a
larger interval while being responsive when external state is more likely to change quickly for certain objects.

Closes #152