### PR TITLE
Fix table rendering in Customize hook design doc

### DIFF
--- a/docs/_design/customize-hook.md
+++ b/docs/_design/customize-hook.md
@@ -53,6 +53,7 @@ The `relatedResources` field should contain a flat list of objects,
 not an associative array.
 
 Each resource rule object should be a JSON object with the following fields:
+
 | Field | Description |
 | ----- | ----------- |
 | `apiVersion` | The API `<group>/<version>` of the parent resource, or just `<version>` for core APIs. (e.g. `v1`, `apps/v1`, `batch/v1`) |


### PR DESCRIPTION
Needed a blank line before the table.